### PR TITLE
Feat 35 client library

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,6 +20,6 @@ Driver = /usr/lib/x86_64-linux-gnu/odbc/libtdsodbc.so\n\
 Setup = /usr/lib/x86_64-linux-gnu/odbc/libtdsS.so" >> /etc/odbcinst.ini
 
 # Pip command
-RUN pip install .
+RUN pip install .[server]
 
 CMD ["uvicorn", "aind_metadata_service.server:app", "--host", "0.0.0.0", "--port", "5000"]

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ REST service to retrieve metadata from databases.
 
 ### Server Installation
 
-Can be pip installed using `pip install aind_metadata_service[server]`.
+Can be pip installed using `pip install aind-metadata-service[server]`.
 
 Installing `pyodbc`.
 - You may need to install `unixodbc-dev`. You can follow this [https://learn.microsoft.com/en-us/sql/connect/odbc/linux-mac/installing-the-microsoft-odbc-driver-for-sql-server?view=sql-server-ver16](link) for instructions depending on your os.
@@ -23,7 +23,7 @@ Installing `pyodbc`.
 
 ### Client Installation
 
-Can be pip installed with `pip install aind_metadata_service[client]`
+Can be pip installed with `pip install aind-metadata-service[client]`
 
 ### For Development
 

--- a/README.md
+++ b/README.md
@@ -6,6 +6,11 @@
 REST service to retrieve metadata from databases.
 
 ## Installation
+
+### Server Installation
+
+Can be pip installed using `pip install aind_metadata_service[server]`.
+
 Installing `pyodbc`.
 - You may need to install `unixodbc-dev`. You can follow this [https://learn.microsoft.com/en-us/sql/connect/odbc/linux-mac/installing-the-microsoft-odbc-driver-for-sql-server?view=sql-server-ver16](link) for instructions depending on your os.
 
@@ -16,12 +21,13 @@ Installing `pyodbc`.
 
 ```
 
-To use the software, in the root directory, run
-```
-pip install -e .
-```
+### Client Installation
 
-To develop the code, run
+Can be pip installed with `pip install aind_metadata_service[client]`
+
+### For Development
+
+In the root directory, run
 ```
 pip install -e .[dev]
 ```

--- a/doc_template/source/conf.py
+++ b/doc_template/source/conf.py
@@ -5,20 +5,19 @@
 
 # -- Path Setup --------------------------------------------------------------
 import os
-import pathlib
 import sys
 
-from pygit2 import Repository
+import aind_metadata_service
 
 sys.path.insert(0, os.path.abspath("../../src"))
 # -- Project information -----------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#project-information
-head = Repository(pathlib.Path.cwd())
+# head = Repository(pathlib.Path.cwd())
 
-project = str(head).split("/")[-3]
+project = aind_metadata_service.__name__
 copyright = "2022, Allen Institute of Neural Dynamics"
 author = "Allen Institute of Neural Dynamics"
-release = "0.1"
+release = aind_metadata_service.__version__
 
 # -- General configuration ---------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#general-configuration

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,23 +17,31 @@ readme = "README.md"
 dynamic = ["version"]
 
 dependencies = [
-    'pyodbc',
-    'office365-rest-python-client',
-    'aind-data-schema==0.10.1',
-    'fastapi',
-    'uvicorn[standard]',
-    'python-dateutil'
+    'aind-data-schema==0.10.1'
 ]
 
 [project.optional-dependencies]
 dev = [
+    'aind-metadata-service[server]',
+    'aind-metadata-service[client]',
     'black',
     'coverage',
     'flake8',
     'interrogate',
     'isort',
-    'Sphinx',
-    'pygit2'
+    'Sphinx'
+]
+
+server = [
+    'pyodbc',
+    'office365-rest-python-client',
+    'fastapi',
+    'uvicorn[standard]',
+    'python-dateutil'
+]
+
+client = [
+    'requests'
 ]
 
 [tool.setuptools.packages.find]

--- a/src/aind_metadata_service/client.py
+++ b/src/aind_metadata_service/client.py
@@ -1,0 +1,53 @@
+"""Module for client library."""
+import requests
+
+
+class AindMetadataServiceClient:
+    """Class to handle client api calls to the service."""
+
+    def __init__(self, domain: str):
+        """
+        Class constructor
+        Parameters
+        ----------
+        domain : str
+          url of the domain
+        """
+
+        self.domain = domain
+        self.subject_url = f"{self.domain}/subject"
+        self.procedures_url = f"{self.domain}/procedures"
+
+    def get_subject(self, subject_id: str) -> requests.Response:
+        """
+        Retrieve a subject response from the server
+        Parameters
+        ----------
+        subject_id : str
+          id of the subject
+
+        Returns
+        -------
+        requests.Response
+
+        """
+        url = "/".join([self.subject_url, subject_id])
+        with requests.get(url) as response:
+            return response
+
+    def get_procedures(self, subject_id: str) -> requests.Response:
+        """
+        Retrieve a procedures response from the server
+        Parameters
+        ----------
+        subject_id : str
+          id of the subject
+
+        Returns
+        -------
+        requests.Response
+
+        """
+        url = "/".join([self.procedures_url, subject_id])
+        with requests.get(url) as response:
+            return response

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1,0 +1,129 @@
+"""Module to test the aind_metadata_service client."""
+import json
+import unittest
+from unittest import mock
+from unittest.mock import MagicMock, call
+
+import requests
+
+from aind_metadata_service.client import AindMetadataServiceClient
+
+
+class TestAindMetadataServiceClient(unittest.TestCase):
+    """Tests the AindMetadataServiceClient class methods"""
+
+    @mock.patch("requests.get")
+    def test_get_subject(self, mock_get: MagicMock) -> None:
+        """Tests the get_subject method."""
+
+        mock_subject_id = "00000"
+        mock_response = requests.Response()
+        mock_response.status_code = 200
+        mock_response._content = json.dumps(
+            {
+                "message": "Valid Model.",
+                "data": {
+                    "describedBy": "https://acme.com/subject.py",
+                    "schema_version": "0.2.2",
+                    "species": "Mus musculus",
+                    "subject_id": mock_subject_id,
+                    "sex": "Female",
+                    "date_of_birth": "2022-05-01",
+                    "genotype": "wt/wt",
+                    "mgi_allele_ids": None,
+                    "background_strain": None,
+                    "source": None,
+                    "rrid": None,
+                    "restrictions": None,
+                    "breeding_group": "breeding_group_id",
+                    "maternal_id": "00001",
+                    "maternal_genotype": "wt/wt",
+                    "paternal_id": "00002",
+                    "paternal_genotype": "wt/wt",
+                    "light_cycle": None,
+                    "home_cage_enrichment": None,
+                    "wellness_reports": None,
+                    "notes": None,
+                },
+            }
+        ).encode("utf-8")
+
+        mock_get.return_value.__enter__.return_value = mock_response
+
+        ams_client = AindMetadataServiceClient(domain="some_url")
+
+        response = ams_client.get_subject(mock_subject_id)
+
+        mock_get.assert_has_calls(
+            [
+                call("some_url/subject/00000"),
+                call().__enter__(),
+                call().__exit__(None, None, None),
+            ]
+        )
+
+        self.assertEqual(200, response.status_code)
+        self.assertEqual(mock_response.json(), response.json())
+
+    @mock.patch("requests.get")
+    def test_get_procedures(self, mock_get: MagicMock) -> None:
+        """Tests the get_procedures method."""
+
+        mock_subject_id = "00000"
+        mock_response = requests.Response()
+        mock_response.status_code = 418
+        mock_response._content = json.dumps(
+            {
+                "message": "Validation Errors: 8 validation errors for "
+                "Procedures\nheadframes\n  'NoneType' object is not "
+                "iterable (type=type_error)\ncraniotomies\n  "
+                "'NoneType' object is not iterable "
+                "(type=type_error)\nmri_scans\n  'NoneType' object is "
+                "not iterable (type=type_error)\ninjections\n  "
+                "'NoneType' object is not iterable "
+                "(type=type_error)\nfiber_implants\n  "
+                "'NoneType' object is not iterable "
+                "(type=type_error)\ntraining_protocols\n  "
+                "'NoneType' object is not iterable "
+                "(type=type_error)\ntissue_preparations\n  "
+                "'NoneType' object is not iterable "
+                "(type=type_error)\nother_procedures\n  "
+                "'NoneType' object is not iterable (type=type_error)",
+                "data": {
+                    "describedBy": "https://acme.com/procedures.py",
+                    "schema_version": "0.4.4",
+                    "subject_id": mock_subject_id,
+                    "headframes": None,
+                    "craniotomies": None,
+                    "mri_scans": None,
+                    "injections": None,
+                    "fiber_implants": None,
+                    "water_restriction": None,
+                    "training_protocols": None,
+                    "tissue_preparations": None,
+                    "other_procedures": None,
+                    "notes": None,
+                },
+            }
+        ).encode("utf-8")
+
+        mock_get.return_value.__enter__.return_value = mock_response
+
+        ams_client = AindMetadataServiceClient(domain="some_url")
+
+        response = ams_client.get_procedures(mock_subject_id)
+
+        mock_get.assert_has_calls(
+            [
+                call("some_url/procedures/00000"),
+                call().__enter__(),
+                call().__exit__(None, None, None),
+            ]
+        )
+
+        self.assertEqual(418, response.status_code)
+        self.assertEqual(mock_response.json(), response.json())
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #35 

- Creates the framework for a client to interface with the service.
- Instead of using curl or requests, can be invoked like
- Can add more detailed handlers in the future
```
from aind_metadata_service.client import AindMetadataServiceClient
ams_client = AindMetadataServiceClient("http://location_of_service")
response = ams_client.get_subject("12345")
```
