### PR TITLE
build: moves aind-data-schema to server list

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,6 @@ readme = "README.md"
 dynamic = ["version"]
 
 dependencies = [
-    'aind-data-schema==0.12.9'
 ]
 
 [project.optional-dependencies]
@@ -33,6 +32,7 @@ dev = [
 ]
 
 server = [
+    'aind-data-schema==0.12.9',
     'pyodbc',
     'office365-rest-python-client',
     'fastapi',


### PR DESCRIPTION
Closes #74

- Moves aind-data-schema to server dependency list
- It isn't needed by the client and may cause dependency conflicts for projects that use the client and aind-data-schema