### PR TITLE
Refactor 98 try except

### DIFF
--- a/src/aind_metadata_service/labtracks/client.py
+++ b/src/aind_metadata_service/labtracks/client.py
@@ -1,4 +1,5 @@
 """Module to create clients to connect to databases."""
+import logging
 from enum import Enum
 from typing import List, Optional
 from xml.etree import ElementTree as ET
@@ -110,7 +111,8 @@ class LabTracksClient:
                     subject = subjects[0]
                     response = Responses.model_response(subject)
                     return response
-        except pyodbc.Error:
+        except Exception as e:
+            logging.error(repr(e))
             return Responses.internal_server_error_response()
 
     def get_procedures_info(self, subject_id: str) -> JSONResponse:
@@ -142,7 +144,8 @@ class LabTracksClient:
                 procedures.subject_procedures = subject_procedures
                 response = Responses.model_response(procedures)
             return response
-        except pyodbc.Error:
+        except Exception as e:
+            logging.error(repr(e))
             return Responses.internal_server_error_response()
 
 

--- a/src/aind_metadata_service/response_handler.py
+++ b/src/aind_metadata_service/response_handler.py
@@ -5,6 +5,7 @@ from typing import List
 from fastapi.encoders import jsonable_encoder
 from fastapi.responses import JSONResponse
 from pydantic import BaseModel, validate_model
+import logging
 
 from aind_metadata_service.client import StatusCodes
 
@@ -118,77 +119,81 @@ class Responses:
         Combines JSONResponses from Labtracks and Sharepoint clients.
         Handles validation errors and special cases.
         """
-        lb_contents = json.loads(lb_response.body)
-        sp_contents = json.loads(sp_response.body)
-        sp_status_code = sp_response.status_code
-        lb_status_code = lb_response.status_code
-        if sp_status_code == 500 and lb_status_code == 500:
+        try:
+            lb_contents = json.loads(lb_response.body)
+            sp_contents = json.loads(sp_response.body)
+            sp_status_code = sp_response.status_code
+            lb_status_code = lb_response.status_code
+            if sp_status_code == 500 and lb_status_code == 500:
+                return Responses.internal_server_error_response()
+            if sp_status_code == 503 and lb_status_code == 503:
+                return Responses.connection_error_response()
+            if sp_status_code == 404 and lb_status_code == 404:
+                return Responses.no_data_found_response()
+            if sp_status_code < 300 and lb_status_code == 404:
+                return sp_response
+            if sp_status_code == 404 and lb_status_code < 300:
+                return lb_response
+            # handles combination of invalid responses
+            if lb_status_code == 406 and sp_status_code == 406:
+                lb_data = lb_contents["data"]["subject_procedures"]
+                sp_data = sp_contents["data"]["subject_procedures"]
+                combined_data = lb_data + sp_data
+                lb_contents["data"]["subject_procedures"] = combined_data
+                message1 = sp_contents["message"]
+                message2 = lb_contents["message"]
+                return JSONResponse(
+                    status_code=StatusCodes.INVALID_DATA.value,
+                    content=(
+                        {
+                            "message": f"Message 1: {message1}, "
+                            f"Message 2: {message2}",
+                            "data": lb_contents["data"],
+                        }
+                    ),
+                )
+            # handles combinations of valid and invalid responses
+            if (sp_status_code < 300 and lb_status_code == 406) or (
+                lb_status_code < 300 and sp_status_code == 406
+            ):
+                lb_data = lb_contents["data"]["subject_procedures"]
+                sp_data = sp_contents["data"]["subject_procedures"]
+                combined_data = lb_data + sp_data
+                sp_contents["data"]["subject_procedures"] = combined_data
+                return Responses.multi_status_response(
+                    message1=sp_contents["message"],
+                    message2=lb_contents["message"],
+                    data=sp_contents["data"],
+                )
+            # handles case when both responses are valid
+            if sp_status_code < 300 and lb_status_code < 300:
+                lb_data = lb_contents["data"]["subject_procedures"]
+                sp_data = sp_contents["data"]["subject_procedures"]
+                combined_data = lb_data + sp_data
+                lb_contents["data"]["subject_procedures"] = combined_data
+                return JSONResponse(
+                    status_code=StatusCodes.VALID_DATA.value,
+                    content=(
+                        {"message": "Valid Model.", "data": lb_contents["data"]}
+                    ),
+                )
+            # handles combination of server/connection error and valid response
+            if sp_status_code in (500, 503) and lb_status_code < 300:
+                lb_data = lb_contents["data"]["subject_procedures"]
+                lb_contents["data"]["subject_procedures"] = lb_data
+                return Responses.multi_status_response(
+                    message1=sp_contents["message"],
+                    message2=lb_contents["message"],
+                    data=lb_contents["data"],
+                )
+            if sp_status_code < 300 and lb_status_code in (500, 503):
+                sp_data = sp_contents["data"]["subject_procedures"]
+                sp_contents["data"]["subject_procedures"] = sp_data
+                return Responses.multi_status_response(
+                    message1=sp_contents["message"],
+                    message2=lb_contents["message"],
+                    data=sp_contents["data"],
+                )
+        except Exception as e:
+            logging.error(repr(e))
             return Responses.internal_server_error_response()
-        if sp_status_code == 503 and lb_status_code == 503:
-            return Responses.connection_error_response()
-        if sp_status_code == 404 and lb_status_code == 404:
-            return Responses.no_data_found_response()
-        if sp_status_code < 300 and lb_status_code == 404:
-            return sp_response
-        if sp_status_code == 404 and lb_status_code < 300:
-            return lb_response
-        # handles combination of invalid responses
-        if lb_status_code == 406 and sp_status_code == 406:
-            lb_data = lb_contents["data"]["subject_procedures"]
-            sp_data = sp_contents["data"]["subject_procedures"]
-            combined_data = lb_data + sp_data
-            lb_contents["data"]["subject_procedures"] = combined_data
-            message1 = sp_contents["message"]
-            message2 = lb_contents["message"]
-            return JSONResponse(
-                status_code=StatusCodes.INVALID_DATA.value,
-                content=(
-                    {
-                        "message": f"Message 1: {message1}, "
-                        f"Message 2: {message2}",
-                        "data": lb_contents["data"],
-                    }
-                ),
-            )
-        # handles combinations of valid and invalid responses
-        if (sp_status_code < 300 and lb_status_code == 406) or (
-            lb_status_code < 300 and sp_status_code == 406
-        ):
-            lb_data = lb_contents["data"]["subject_procedures"]
-            sp_data = sp_contents["data"]["subject_procedures"]
-            combined_data = lb_data + sp_data
-            sp_contents["data"]["subject_procedures"] = combined_data
-            return Responses.multi_status_response(
-                message1=sp_contents["message"],
-                message2=lb_contents["message"],
-                data=sp_contents["data"],
-            )
-        # handles case when both responses are valid
-        if sp_status_code < 300 and lb_status_code < 300:
-            lb_data = lb_contents["data"]["subject_procedures"]
-            sp_data = sp_contents["data"]["subject_procedures"]
-            combined_data = lb_data + sp_data
-            lb_contents["data"]["subject_procedures"] = combined_data
-            return JSONResponse(
-                status_code=StatusCodes.VALID_DATA.value,
-                content=(
-                    {"message": "Valid Model.", "data": lb_contents["data"]}
-                ),
-            )
-        # handles combination of server/connection error and valid response
-        if sp_status_code in (500, 503) and lb_status_code < 300:
-            lb_data = lb_contents["data"]["subject_procedures"]
-            lb_contents["data"]["subject_procedures"] = lb_data
-            return Responses.multi_status_response(
-                message1=sp_contents["message"],
-                message2=lb_contents["message"],
-                data=lb_contents["data"],
-            )
-        if sp_status_code < 300 and lb_status_code in (500, 503):
-            sp_data = sp_contents["data"]["subject_procedures"]
-            sp_contents["data"]["subject_procedures"] = sp_data
-            return Responses.multi_status_response(
-                message1=sp_contents["message"],
-                message2=lb_contents["message"],
-                data=sp_contents["data"],
-            )

--- a/src/aind_metadata_service/response_handler.py
+++ b/src/aind_metadata_service/response_handler.py
@@ -1,11 +1,11 @@
 """Module to handle responses"""
 import json
+import logging
 from typing import List
 
 from fastapi.encoders import jsonable_encoder
 from fastapi.responses import JSONResponse
 from pydantic import BaseModel, validate_model
-import logging
 
 from aind_metadata_service.client import StatusCodes
 
@@ -174,7 +174,10 @@ class Responses:
                 return JSONResponse(
                     status_code=StatusCodes.VALID_DATA.value,
                     content=(
-                        {"message": "Valid Model.", "data": lb_contents["data"]}
+                        {
+                            "message": "Valid Model.",
+                            "data": lb_contents["data"],
+                        }
                     ),
                 )
             # handles combination of server/connection error and valid response

--- a/src/aind_metadata_service/sharepoint/client.py
+++ b/src/aind_metadata_service/sharepoint/client.py
@@ -4,6 +4,7 @@ from aind_data_schema.procedures import Procedures
 from fastapi.responses import JSONResponse
 from office365.runtime.auth.client_credential import ClientCredential
 from office365.sharepoint.client_context import ClientContext
+import logging
 
 from aind_metadata_service.response_handler import Responses
 from aind_metadata_service.sharepoint.nsb2019.procedures import (
@@ -63,27 +64,30 @@ class SharePointClient:
           A response
 
         """
-        # TODO: Add try to handle internal server error response.
-        subject_procedures = []
-        nsb_ctx = self.nsb_client_context
-        nsb_2019_mapper = NSB2019Procedures()
-        nsb_2023_mapper = NSB2023Procedures()
-        procedures2019 = nsb_2019_mapper.get_procedures_from_sharepoint(
-            subject_id=subject_id,
-            client_context=nsb_ctx,
-            list_title=self.nsb_list_title_2019,
-        )
-        procedures2023 = nsb_2023_mapper.get_procedures_from_sharepoint(
-            subject_id=subject_id,
-            client_context=nsb_ctx,
-            list_title=self.nsb_list_title_2023,
-        )
-        subject_procedures.extend(procedures2019)
-        subject_procedures.extend(procedures2023)
-        response = self._handle_response_from_sharepoint(
-            subject_id=subject_id, subject_procedures=subject_procedures
-        )
-        return response
+        try:
+            subject_procedures = []
+            nsb_ctx = self.nsb_client_context
+            nsb_2019_mapper = NSB2019Procedures()
+            nsb_2023_mapper = NSB2023Procedures()
+            procedures2019 = nsb_2019_mapper.get_procedures_from_sharepoint(
+                subject_id=subject_id,
+                client_context=nsb_ctx,
+                list_title=self.nsb_list_title_2019,
+            )
+            procedures2023 = nsb_2023_mapper.get_procedures_from_sharepoint(
+                subject_id=subject_id,
+                client_context=nsb_ctx,
+                list_title=self.nsb_list_title_2023,
+            )
+            subject_procedures.extend(procedures2019)
+            subject_procedures.extend(procedures2023)
+            response = self._handle_response_from_sharepoint(
+                subject_id=subject_id, subject_procedures=subject_procedures
+            )
+            return response
+        except Exception as e:
+            logging.error(repr(e))
+            return Responses.internal_server_error_response()
 
     @staticmethod
     def _handle_response_from_sharepoint(

--- a/src/aind_metadata_service/sharepoint/client.py
+++ b/src/aind_metadata_service/sharepoint/client.py
@@ -1,10 +1,11 @@
 """Module to create client to connect to sharepoint database"""
 
+import logging
+
 from aind_data_schema.procedures import Procedures
 from fastapi.responses import JSONResponse
 from office365.runtime.auth.client_credential import ClientCredential
 from office365.sharepoint.client_context import ClientContext
-import logging
 
 from aind_metadata_service.response_handler import Responses
 from aind_metadata_service.sharepoint.nsb2019.procedures import (


### PR DESCRIPTION
Closes #98 

- Wraps get methods with try clauses. Logs error and returns Internal ServerError Response
- Should hopefully prevent the service from crashing on non-fatal exceptions
- updates the unit tests
- fixes a relative import