### PR TITLE
Feat 171 molecule tars

### DIFF
--- a/src/aind_metadata_service/response_handler.py
+++ b/src/aind_metadata_service/response_handler.py
@@ -4,7 +4,7 @@ import pickle
 from typing import Generic, List, Optional, TypeVar, Union
 
 from aind_data_schema.core.data_description import Funding
-from aind_data_schema.core.procedures import Procedures, InjectionMaterial
+from aind_data_schema.core.procedures import InjectionMaterial, Procedures
 from aind_data_schema.core.subject import Subject
 from fastapi import Response
 from fastapi.encoders import jsonable_encoder

--- a/src/aind_metadata_service/tars/client.py
+++ b/src/aind_metadata_service/tars/client.py
@@ -87,7 +87,7 @@ class TarsClient:
         Parameters
         ----------
         plasmid_name: str
-           Prep lot number used to query ViralPrepLot endpoint.
+           Plasmid name used to query Molecules endpoint.
         """
         headers = self._headers
         query = (

--- a/src/aind_metadata_service/tars/client.py
+++ b/src/aind_metadata_service/tars/client.py
@@ -114,7 +114,10 @@ class TarsClient:
                 viral_prep_aliases = trh.map_virus_aliases(
                     aliases=lot["viralPrep"]["virus"]["aliases"]
                 )
-                if viral_prep_aliases.plasmid_name and viral_prep_aliases.full_genome_name is None:
+                if (
+                    viral_prep_aliases.plasmid_name
+                    and viral_prep_aliases.full_genome_name is None
+                ):
                     # check molecular registry for full genome name
                     molecule_response = self._get_molecules_response(
                         viral_prep_aliases.plasmid_name

--- a/src/aind_metadata_service/tars/client.py
+++ b/src/aind_metadata_service/tars/client.py
@@ -77,6 +77,26 @@ class TarsClient:
         response = requests.get(query, headers=headers)
         return response
 
+    def _get_molecules_response(
+        self, plasmid_name: str
+    ) -> requests.models.Response:
+        """
+        Retrieves molecules from TARS.
+        Parameters
+        ----------
+        plasmid_name: str
+           Prep lot number used to query ViralPrepLot endpoint.
+        """
+        headers = self._headers
+        query = (
+            f"{self.resource}/api/v1/Molecules"
+            f"?order=1&orderBy=id"
+            f"&searchFields=name"
+            f"&search={plasmid_name}"
+        )
+        response = requests.get(query, headers=headers)
+        return response
+
     def get_injection_materials_info(
         self, prep_lot_number: str
     ) -> ModelResponse:

--- a/src/aind_metadata_service/tars/client.py
+++ b/src/aind_metadata_service/tars/client.py
@@ -114,7 +114,7 @@ class TarsClient:
                 viral_prep_aliases = trh.map_virus_aliases(
                     aliases=lot["viralPrep"]["virus"]["aliases"]
                 )
-                if viral_prep_aliases.plasmid_name:
+                if viral_prep_aliases.plasmid_name and viral_prep_aliases.full_genome_name is None:
                     # check molecular registry for full genome name
                     molecule_response = self._get_molecules_response(
                         viral_prep_aliases.plasmid_name

--- a/src/aind_metadata_service/tars/mapping.py
+++ b/src/aind_metadata_service/tars/mapping.py
@@ -6,7 +6,7 @@ from enum import Enum
 from typing import Optional
 
 from aind_data_schema.core.procedures import InjectionMaterial, VirusPrepType
-from pydantic import BaseModel, Field
+from dataclasses import dataclass
 
 
 class ViralPrepTypes(Enum):
@@ -49,12 +49,13 @@ class VirusAliasPatterns(Enum):
     AIV = re.compile(r"^AiV[a-zA-Z0-9_-]+$")
 
 
-class ViralPrepAliases(BaseModel):
+@dataclass
+class ViralPrepAliases:
     """Model for mapping viral prep aliases"""
 
-    plasmid_name: str = Field(..., title="Plasmid name")
-    material_id: str = Field(..., title="Material ID")
-    full_genome_name: str = Field(..., title="Full genome name")
+    plasmid_name: str
+    material_id: str
+    full_genome_name: str
 
 
 class TarsResponseHandler:
@@ -125,7 +126,7 @@ class TarsResponseHandler:
                 material_id = name
             else:
                 full_genome_name = name
-        viral_prep_aliases = ViralPrepAliases.model_construct(
+        viral_prep_aliases = ViralPrepAliases(
             plasmid_name=plasmid_name,
             material_id=material_id,
             full_genome_name=full_genome_name,
@@ -133,7 +134,7 @@ class TarsResponseHandler:
         return viral_prep_aliases
 
     @staticmethod
-    def map_full_genome_name(response, plasmid_name) -> str:
+    def map_full_genome_name(response, plasmid_name) -> Optional[str]:
         """Maps genome name from molecular response"""
         full_genome_name = None
         data = response.json()["data"][0]
@@ -141,6 +142,7 @@ class TarsResponseHandler:
         for alias in aliases:
             if alias["name"] != plasmid_name:
                 full_genome_name = alias["name"]
+                break
         return full_genome_name
 
     def map_lot_to_injection_material(

--- a/src/aind_metadata_service/tars/mapping.py
+++ b/src/aind_metadata_service/tars/mapping.py
@@ -53,9 +53,9 @@ class VirusAliasPatterns(Enum):
 class ViralPrepAliases:
     """Model for mapping viral prep aliases"""
 
-    plasmid_name: str
-    material_id: str
-    full_genome_name: str
+    plasmid_name: Optional[str]
+    material_id: Optional[str]
+    full_genome_name: Optional[str]
 
 
 class TarsResponseHandler:

--- a/src/aind_metadata_service/tars/mapping.py
+++ b/src/aind_metadata_service/tars/mapping.py
@@ -64,7 +64,7 @@ class TarsResponseHandler:
     @staticmethod
     def _map_prep_type_and_protocol(
         viral_prep_type: str,
-    ) -> tuple[VirusPrepType, str]:
+    ) -> tuple[Optional[VirusPrepType], Optional[str]]:
         """Maps TARS viral prep type to prep_type and prep_protocol"""
         if viral_prep_type == ViralPrepTypes.CRUDE_SOP.value:
             prep_type = VirusPrepType.CRUDE

--- a/src/aind_metadata_service/tars/mapping.py
+++ b/src/aind_metadata_service/tars/mapping.py
@@ -1,8 +1,10 @@
 """Module to map data in TARS to aind_data_schema InjectionMaterial"""
 
-import datetime
 import re
+from datetime import date, datetime
 from enum import Enum
+from typing import Optional
+
 from aind_data_schema.core.procedures import InjectionMaterial, VirusPrepType
 from pydantic import BaseModel, Field
 
@@ -98,7 +100,7 @@ class TarsResponseHandler:
         return prep_type, prep_protocol
 
     @staticmethod
-    def _convert_datetime(date: str) -> datetime.date:
+    def _convert_datetime(date: str) -> Optional[date]:
         """Converts date string to datetime date"""
         # Is it safe to assume it'll always be in this pattern
         date_pattern = re.compile(r"^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z$")
@@ -109,7 +111,7 @@ class TarsResponseHandler:
                 " Please provide a date in the format: YYYY-MM-DDTHH:MM:SSZ"
             )
             return None
-        return datetime.datetime.strptime(date, "%Y-%m-%dT%H:%M:%SZ").date()
+        return datetime.strptime(date, "%Y-%m-%dT%H:%M:%SZ").date()
 
     @staticmethod
     def map_virus_aliases(aliases: list) -> ViralPrepAliases:
@@ -131,7 +133,7 @@ class TarsResponseHandler:
         return viral_prep_aliases
 
     @staticmethod
-    def map_full_genome_name(response, plasmid_name):
+    def map_full_genome_name(response, plasmid_name) -> str:
         """Maps genome name from molecular response"""
         full_genome_name = None
         data = response.json()["data"][0]

--- a/src/aind_metadata_service/tars/mapping.py
+++ b/src/aind_metadata_service/tars/mapping.py
@@ -1,12 +1,12 @@
 """Module to map data in TARS to aind_data_schema InjectionMaterial"""
 
 import re
+from dataclasses import dataclass
 from datetime import date, datetime
 from enum import Enum
 from typing import Optional
 
 from aind_data_schema.core.procedures import InjectionMaterial, VirusPrepType
-from dataclasses import dataclass
 
 
 class ViralPrepTypes(Enum):
@@ -139,10 +139,11 @@ class TarsResponseHandler:
         full_genome_name = None
         data = response.json()["data"][0]
         aliases = data["aliases"]
-        for alias in aliases:
-            if alias["name"] != plasmid_name:
-                full_genome_name = alias["name"]
-                break
+        if len(aliases) == 2:
+            if aliases[0]["name"] != plasmid_name:
+                full_genome_name = aliases[0]["name"]
+            elif aliases[1]["name"] != plasmid_name:
+                full_genome_name = aliases[1]["name"]
         return full_genome_name
 
     def map_lot_to_injection_material(

--- a/tests/resources/tars/mapped_materials.json
+++ b/tests/resources/tars/mapped_materials.json
@@ -1,17 +1,15 @@
-[
-  {
+{
     "name":"rAAV-MGT_789",
-    "material_id":"AiP123",
+    "material_id":"AiV456",
     "prep_lot_number":"12345",
-    "prep_date":"2023-12-15T12:34:56",
+    "prep_date":"2023-12-15 00:00:00",
     "prep_type":"Crude",
     "prep_protocol":"SOP#VC002",
-    "full_genome_name":null,
-    "plasmid_name":null,
+    "full_genome_name":"rAAV-MGT_789",
+    "plasmid_name":"AiP123",
     "genome_copy":null,
     "titer":null,
     "titer_unit":"gc/mL",
     "concentration":null,
     "concentration_unit":null
   }
-]

--- a/tests/tars/test_client.py
+++ b/tests/tars/test_client.py
@@ -4,7 +4,8 @@ import json
 import os
 import unittest
 from pathlib import Path
-from unittest.mock import Mock, MagicMock, patch
+from unittest.mock import MagicMock, Mock, patch
+
 from aind_data_schema.core.procedures import InjectionMaterial
 
 from aind_metadata_service.response_handler import ModelResponse, StatusCodes

--- a/tests/tars/test_client.py
+++ b/tests/tars/test_client.py
@@ -144,6 +144,9 @@ class TestTarsClient(unittest.TestCase):
             f"&search=AiP123"
         )
 
+        self.assertEqual(
+            result.json()["data"][0]["aliases"][0]["name"], "AiP123"
+        )
         mock_get.assert_called_once_with(
             expected_url, headers=self.tars_client._headers
         )

--- a/tests/tars/test_client.py
+++ b/tests/tars/test_client.py
@@ -124,6 +124,30 @@ class TestTarsClient(unittest.TestCase):
             expected_url, headers=self.tars_client._headers
         )
 
+    @patch("aind_metadata_service.tars.client.requests.get")
+    def test_get_molecules_response(self, mock_get):
+        """Tests that client can fetch viral prep lot."""
+
+        mock_response = Mock()
+
+        mock_response.json.return_value = {
+            "data": [
+                {"aliases": [{"name": "AiP123"}, {"name": "rAAV-MGT_789"}]}
+            ]
+        }
+        mock_get.return_value = mock_response
+        result = self.tars_client._get_molecules_response("AiP123")
+        expected_url = (
+            f"{self.resource}/api/v1/Molecules"
+            f"?order=1&orderBy=id"
+            f"&searchFields=name"
+            f"&search=AiP123"
+        )
+
+        mock_get.assert_called_once_with(
+            expected_url, headers=self.tars_client._headers
+        )
+
     @patch(
         "aind_metadata_service.tars.client.TarsClient._get_prep_lot_response"
     )

--- a/tests/tars/test_mapping.py
+++ b/tests/tars/test_mapping.py
@@ -133,15 +133,39 @@ class TestTarsResponseHandler(unittest.TestCase):
                 {"aliases": [{"name": "AiP123"}, {"name": "rAAV-MGT_789"}]}
             ]
         }
+        response_data2 = {
+            "data": [
+                {"aliases": [{"name": "rAAV-MGT_789"}, {"name": "AiP123"}]}
+            ]
+        }
+        response_data3 = {
+            "data": [{"aliases": [{"name": None}, {"name": "AiP123"}]}]
+        }
         mock_response = MagicMock()
         mock_response.json.return_value = response_data
+
+        mock_response2 = MagicMock()
+        mock_response2.json.return_value = response_data2
+
+        mock_response3 = MagicMock()
+        mock_response3.json.return_value = response_data3
 
         handler = TarsResponseHandler()
         genome_name = handler.map_full_genome_name(
             mock_response, plasmid_name="AiP123"
         )
 
+        genome_name2 = handler.map_full_genome_name(
+            mock_response2, plasmid_name="AiP123"
+        )
+
+        genome_name3 = handler.map_full_genome_name(
+            mock_response3, plasmid_name="AiP123"
+        )
+
         self.assertEqual(genome_name, "rAAV-MGT_789")
+        self.assertEqual(genome_name2, "rAAV-MGT_789")
+        self.assertIsNone(genome_name3)
 
     def test_map_lot_to_injection_materials(self):
         """Tests that prep lot is mapped to InjectionMaterial as expected."""

--- a/tests/tars/test_mapping.py
+++ b/tests/tars/test_mapping.py
@@ -127,7 +127,7 @@ class TestTarsResponseHandler(unittest.TestCase):
         self.assertEqual(viral_prep_aliases.full_genome_name, "UnknownVirus")
 
     def test_map_full_genome_name(self):
-        """"""
+        """Tests that genome name is mapped as expected."""
         response_data = {
             "data": [
                 {"aliases": [{"name": "AiP123"}, {"name": "rAAV-MGT_789"}]}

--- a/tests/tars/test_mapping.py
+++ b/tests/tars/test_mapping.py
@@ -1,12 +1,13 @@
 """Module to test TARS mapping."""
+import datetime
 import unittest
-from datetime import datetime
 from unittest.mock import MagicMock
 
 from aind_metadata_service.tars.mapping import (
     InjectionMaterial,
     PrepProtocols,
     TarsResponseHandler,
+    ViralPrepAliases,
     ViralPrepTypes,
     VirusPrepType,
 )
@@ -104,7 +105,7 @@ class TestTarsResponseHandler(unittest.TestCase):
         invalid_date = "12/15/2023"
 
         converted_date = TarsResponseHandler._convert_datetime(valid_date)
-        self.assertIsInstance(converted_date, datetime)
+        self.assertIsInstance(converted_date, datetime.date)
 
         converted_invalid_date = TarsResponseHandler._convert_datetime(
             invalid_date
@@ -119,57 +120,66 @@ class TestTarsResponseHandler(unittest.TestCase):
             {"name": "UnknownVirus"},
         ]
 
-        (
-            material_id,
-            viral_prep_id,
-            full_genome_name,
-        ) = TarsResponseHandler._map_virus_aliases(aliases)
+        viral_prep_aliases = TarsResponseHandler.map_virus_aliases(aliases)
 
-        self.assertEqual(material_id, "AiP123")
-        self.assertEqual(viral_prep_id, "AiV456")
-        self.assertEqual(full_genome_name, "UnknownVirus")
+        self.assertEqual(viral_prep_aliases.plasmid_name, "AiP123")
+        self.assertEqual(viral_prep_aliases.material_id, "AiV456")
+        self.assertEqual(viral_prep_aliases.full_genome_name, "UnknownVirus")
 
-    def test_map_response_to_injection_materials(self):
-        """Tests that injection materials are mapped as expected."""
+    def test_map_full_genome_name(self):
+        """"""
         response_data = {
             "data": [
-                {
-                    "lot": "12345",
-                    "datePrepped": "2023-12-15T12:34:56Z",
-                    "viralPrep": {
-                        "viralPrepType": {
-                            "name": ViralPrepTypes.CRUDE_SOP.value
-                        },
-                        "virus": {
-                            "aliases": [
-                                {"name": "AiP123"},
-                                {"name": "AiV456"},
-                                {"name": "rAAV-MGT_789"},
-                            ]
-                        },
-                    },
-                }
+                {"aliases": [{"name": "AiP123"}, {"name": "rAAV-MGT_789"}]}
             ]
         }
         mock_response = MagicMock()
         mock_response.json.return_value = response_data
 
         handler = TarsResponseHandler()
-        injection_material = handler.map_response_to_injection_materials(
-            mock_response
+        genome_name = handler.map_full_genome_name(
+            mock_response, plasmid_name="AiP123"
         )
-        expected_injection_material = InjectionMaterial.model_construct(
-            name="rAAV-MGT_789",
+
+        self.assertEqual(genome_name, "rAAV-MGT_789")
+
+    def test_map_lot_to_injection_materials(self):
+        """Tests that prep lot is mapped to InjectionMaterial as expected."""
+        response_data = {
+            "lot": "12345",
+            "datePrepped": "2023-12-15T12:34:56Z",
+            "viralPrep": {
+                "viralPrepType": {"name": ViralPrepTypes.CRUDE_SOP.value},
+                "virus": {
+                    "aliases": [
+                        {"name": "AiP123"},
+                        {"name": "AiV456"},
+                    ]
+                },
+            },
+        }
+
+        handler = TarsResponseHandler()
+        viral_prep_aliases = ViralPrepAliases(
             material_id="AiV456",
-            prep_lot_number="12345",
-            prep_date=datetime(2023, 12, 15, 12, 34, 56),
-            prep_type=VirusPrepType.CRUDE,
-            prep_protocol="SOP#VC002",
             full_genome_name="rAAV-MGT_789",
             plasmid_name="AiP123",
         )
-        self.assertIsInstance(injection_material[0], InjectionMaterial)
-        self.assertEqual(injection_material[0], expected_injection_material)
+        injection_material = handler.map_lot_to_injection_material(
+            viral_prep_lot=response_data, viral_prep_aliases=viral_prep_aliases
+        )
+        expected_injection_material = InjectionMaterial.model_construct(
+            name="rAAV-MGT_789",
+            full_genome_name="rAAV-MGT_789",
+            material_id="AiV456",
+            prep_lot_number="12345",
+            prep_date=datetime.date(2023, 12, 15),
+            prep_type=VirusPrepType.CRUDE,
+            prep_protocol="SOP#VC002",
+            plasmid_name="AiP123",
+        )
+        self.assertIsInstance(injection_material, InjectionMaterial)
+        self.assertEqual(injection_material, expected_injection_material)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
closes #171 

Refactors the TARS client and mapping to integrate responses from viral prep lot and molecular registry in TARS into InjectionMaterials. Also defines a model ViralPrepAliases for mapping of aliases in TARS (instead of tuple)