### PR TITLE
feat 166: adds tars endpoint

### DIFF
--- a/doc_template/source/conf.py
+++ b/doc_template/source/conf.py
@@ -1,4 +1,5 @@
 """Configuration file for the Sphinx documentation builder."""
+
 #
 # For the full list of built-in configuration values, see the documentation:
 # https://www.sphinx-doc.org/en/master/usage/configuration.html

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,8 @@ dynamic = ["version"]
 
 dependencies = [
     'aind-data-schema==0.19.0',
-    'pydantic-settings==2.1.0'
+    'pydantic-settings==2.1.0',
+    'pydantic==2.5'
 ]
 
 [project.optional-dependencies]

--- a/src/aind_metadata_service/__init__.py
+++ b/src/aind_metadata_service/__init__.py
@@ -1,3 +1,4 @@
 """REST service to retrieve metadata from databases.
 """
+
 __version__ = "0.8.1"

--- a/src/aind_metadata_service/client.py
+++ b/src/aind_metadata_service/client.py
@@ -1,4 +1,5 @@
 """Module for client library."""
+
 from enum import Enum
 
 import requests

--- a/src/aind_metadata_service/labtracks/client.py
+++ b/src/aind_metadata_service/labtracks/client.py
@@ -1,4 +1,5 @@
 """Module to create clients to connect to labtracks database."""
+
 import logging
 from enum import Enum
 from typing import List, Optional

--- a/src/aind_metadata_service/labtracks/query_builder.py
+++ b/src/aind_metadata_service/labtracks/query_builder.py
@@ -1,4 +1,5 @@
 """Module that returns appropriate sql query strings"""
+
 from enum import Enum
 
 

--- a/src/aind_metadata_service/response_handler.py
+++ b/src/aind_metadata_service/response_handler.py
@@ -1,4 +1,5 @@
 """Module to handle responses"""
+
 import json
 import pickle
 from typing import Generic, List, Optional, TypeVar, Union
@@ -60,6 +61,15 @@ class ModelResponse(Generic[T]):
             status_code=StatusCodes.INTERNAL_SERVER_ERROR,
             aind_models=[],
             message="Internal Server Error.",
+        )
+
+    @classmethod
+    def no_data_found_error_response(cls):
+        """No Data Found Error"""
+        return cls(
+            status_code=StatusCodes.NO_DATA_FOUND,
+            aind_models=[],
+            message="No Data Found.",
         )
 
     def _map_data_response(

--- a/src/aind_metadata_service/server.py
+++ b/src/aind_metadata_service/server.py
@@ -23,12 +23,19 @@ from aind_metadata_service.smartsheet.funding.mapping import FundingMapper
 from aind_metadata_service.smartsheet.perfusions.mapping import (
     PerfusionsMapper,
 )
+from aind_metadata_service.tars.client import TarsClient, AzureSettings
 
 SMARTSHEET_FUNDING_ID = os.getenv("SMARTSHEET_FUNDING_ID")
 SMARTSHEET_FUNDING_TOKEN = os.getenv("SMARTSHEET_FUNDING_TOKEN")
 
 SMARTSHEET_PERFUSIONS_ID = os.getenv("SMARTSHEET_PERFUSIONS_ID")
 SMARTSHEET_PERFUSIONS_TOKEN = os.getenv("SMARTSHEET_PERFUSIONS_TOKEN")
+
+TARS_TENANT_ID = os.getenv("TARS_TENANT_ID")
+TARS_CLIENT_ID = os.getenv("TARS_CLIENT_ID")
+TARS_CLIENT_SECRET = os.getenv("TARS_CLIENT_SECRET")
+TARS_SCOPE = os.getenv("TARS_SCOPE")
+TARS_RESOURCE = os.getenv("TARS_RESOURCE")
 
 # TODO: Move client instantiation when the server starts instead of creating
 #  one for each request?
@@ -39,6 +46,9 @@ funding_smartsheet_settings = SmartsheetSettings(
 )
 perfusions_smartsheet_settings = SmartsheetSettings(
     access_token=SMARTSHEET_PERFUSIONS_TOKEN, sheet_id=SMARTSHEET_PERFUSIONS_ID
+)
+tars_settings = AzureSettings(
+    tenant_id=TARS_TENANT_ID, client_id=TARS_CLIENT_ID, client_secret=TARS_CLIENT_SECRET, scope=TARS_SCOPE, resource=TARS_RESOURCE
 )
 
 
@@ -102,6 +112,22 @@ async def retrieve_subject(subject_id, pickle: bool = False):
     lb_client = LabTracksClient.from_settings(labtracks_settings)
     model_response = await run_in_threadpool(
         lb_client.get_subject_info, subject_id=subject_id
+    )
+    if pickle:
+        return model_response.map_to_pickled_response()
+    else:
+        return model_response.map_to_json_response()
+
+
+@app.get("/injection_materials/{prep_lot_number}")
+async def retrieve_injection_materials(prep_lot_number, pickle: bool = False):
+    """
+    Retrieves injection materials from TARS server
+    Returns pickled data if URL parameter pickle=True, else returns json
+    """
+    tars_client = TarsClient(azure_settings=tars_settings)
+    model_response = await run_in_threadpool(
+        tars_client.get_injection_materials_info, prep_lot_number=prep_lot_number
     )
     if pickle:
         return model_response.map_to_pickled_response()

--- a/src/aind_metadata_service/server.py
+++ b/src/aind_metadata_service/server.py
@@ -23,7 +23,7 @@ from aind_metadata_service.smartsheet.funding.mapping import FundingMapper
 from aind_metadata_service.smartsheet.perfusions.mapping import (
     PerfusionsMapper,
 )
-from aind_metadata_service.tars.client import TarsClient, AzureSettings
+from aind_metadata_service.tars.client import AzureSettings, TarsClient
 
 SMARTSHEET_FUNDING_ID = os.getenv("SMARTSHEET_FUNDING_ID")
 SMARTSHEET_FUNDING_TOKEN = os.getenv("SMARTSHEET_FUNDING_TOKEN")
@@ -48,7 +48,11 @@ perfusions_smartsheet_settings = SmartsheetSettings(
     access_token=SMARTSHEET_PERFUSIONS_TOKEN, sheet_id=SMARTSHEET_PERFUSIONS_ID
 )
 tars_settings = AzureSettings(
-    tenant_id=TARS_TENANT_ID, client_id=TARS_CLIENT_ID, client_secret=TARS_CLIENT_SECRET, scope=TARS_SCOPE, resource=TARS_RESOURCE
+    tenant_id=TARS_TENANT_ID,
+    client_id=TARS_CLIENT_ID,
+    client_secret=TARS_CLIENT_SECRET,
+    scope=TARS_SCOPE,
+    resource=TARS_RESOURCE,
 )
 
 
@@ -127,7 +131,8 @@ async def retrieve_injection_materials(prep_lot_number, pickle: bool = False):
     """
     tars_client = TarsClient(azure_settings=tars_settings)
     model_response = await run_in_threadpool(
-        tars_client.get_injection_materials_info, prep_lot_number=prep_lot_number
+        tars_client.get_injection_materials_info,
+        prep_lot_number=prep_lot_number,
     )
     if pickle:
         return model_response.map_to_pickled_response()

--- a/src/aind_metadata_service/server.py
+++ b/src/aind_metadata_service/server.py
@@ -119,7 +119,7 @@ async def retrieve_subject(subject_id, pickle: bool = False):
         return model_response.map_to_json_response()
 
 
-@app.get("/injection_materials/{prep_lot_number}")
+@app.get("/tars_injection_materials/{prep_lot_number}")
 async def retrieve_injection_materials(prep_lot_number, pickle: bool = False):
     """
     Retrieves injection materials from TARS server

--- a/src/aind_metadata_service/sharepoint/client.py
+++ b/src/aind_metadata_service/sharepoint/client.py
@@ -240,9 +240,9 @@ class SharePointClient:
             )
         else:
             left_procedures: List[Procedures] = left_model_response.aind_models
-            right_procedures: List[
-                Procedures
-            ] = right_model_response.aind_models
+            right_procedures: List[Procedures] = (
+                right_model_response.aind_models
+            )
             procedures = self._merge_procedures(
                 left_procedures=left_procedures,
                 right_procedures=right_procedures,

--- a/src/aind_metadata_service/slims/client.py
+++ b/src/aind_metadata_service/slims/client.py
@@ -1,4 +1,5 @@
 """Module for slims client"""
+
 import logging
 
 from pydantic import Extra, Field, SecretStr

--- a/src/aind_metadata_service/tars/client.py
+++ b/src/aind_metadata_service/tars/client.py
@@ -25,12 +25,13 @@ class AzureSettings(BaseSettings):
         ..., description="Secret used to access the account."
     )
     scope: str = Field(..., description="Scope")
+    resource: str = Field(..., description="Resource")
 
 
 class TarsClient:
     """Main client to connect to a TARS"""
 
-    def __init__(self, azure_settings: AzureSettings, resource: str) -> None:
+    def __init__(self, azure_settings: AzureSettings) -> None:
         """
         Class constructor
         Parameters
@@ -46,7 +47,7 @@ class TarsClient:
             client_secret=azure_settings.client_secret.get_secret_value(),
         )
         self.scope = azure_settings.scope
-        self.resource = resource
+        self.resource = azure_settings.resource
 
     @property
     def _access_token(self):

--- a/tests/labtracks/test_response_handler.py
+++ b/tests/labtracks/test_response_handler.py
@@ -1,4 +1,5 @@
 """Module to test LabTracksResponseHandler methods."""
+
 import datetime
 import unittest
 from decimal import Decimal

--- a/tests/sharepoint/test_client.py
+++ b/tests/sharepoint/test_client.py
@@ -375,6 +375,7 @@ class TestSharepointClient(unittest.TestCase):
         ]
         expected_subject_procedures.sort(key=lambda x: str(x))
         actual_subject_procedures.sort(key=lambda x: str(x))
+
         self.assertEqual(
             StatusCodes.MULTI_STATUS, merged_responses.status_code
         )

--- a/tests/tars/test_client.py
+++ b/tests/tars/test_client.py
@@ -21,7 +21,7 @@ class TestAzureSettings(unittest.TestCase):
     EXAMPLE_ENV_VAR1 = {
         "TENANT_ID": "some_tenant",
         "CLIENT_ID": "some_client",
-        "AUTHORITY": "some_authority",
+        "RESOURCE": "some_resource",
         "CLIENT_SECRET": "some_secret",
         "SCOPE": "some_scope",
     }
@@ -33,6 +33,7 @@ class TestAzureSettings(unittest.TestCase):
 
         self.assertEqual("some_tenant", settings1.tenant_id)
         self.assertEqual("some_client", settings1.client_id)
+        self.assertEqual("some_resource", settings1.resource)
         self.assertEqual("some_scope", settings1.scope)
         self.assertEqual(
             "some_secret",
@@ -48,7 +49,7 @@ class TestAzureSettings(unittest.TestCase):
                 tenant_id="some_tenant",
             )
         self.assertIn(
-            "2 validation errors for AzureSettings", repr(e.exception)
+            "3 validation errors for AzureSettings", repr(e.exception)
         )
 
 
@@ -63,9 +64,9 @@ class TestTarsClient(unittest.TestCase):
             client_id="some_client_id",
             client_secret="some_client_secret",
             scope="some_scope",
-        )
+            resource="https://some_resource"
 
-        self.resource = "https://some_resource"
+        )
 
         with open(EXAMPLE_PATH, "r") as f:
             self.expected_materials = json.load(f)
@@ -74,7 +75,7 @@ class TestTarsClient(unittest.TestCase):
             "mock_token",
             "mock_exp",
         )
-        self.tars_client = TarsClient(self.azure_settings, self.resource)
+        self.tars_client = TarsClient(self.azure_settings)
         # mock_credential.return_value.get_token.assert_called_once()
 
     def test_access_token(self):
@@ -114,7 +115,7 @@ class TestTarsClient(unittest.TestCase):
         mock_get.return_value = mock_response
         result = self.tars_client._get_prep_lot_response("12345")
         expected_url = (
-            f"{self.resource}/api/v1/ViralPrepLots"
+            f"{self.azure_settings.resource}/api/v1/ViralPrepLots"
             f"?order=1&orderBy=id"
             f"&searchFields=lot"
             f"&search=12345"
@@ -139,7 +140,7 @@ class TestTarsClient(unittest.TestCase):
         mock_get.return_value = mock_response
         result = self.tars_client._get_molecules_response("AiP123")
         expected_url = (
-            f"{self.resource}/api/v1/Molecules"
+            f"{self.azure_settings.resource}/api/v1/Molecules"
             f"?order=1&orderBy=id"
             f"&searchFields=name"
             f"&search=AiP123"

--- a/tests/tars/test_client.py
+++ b/tests/tars/test_client.py
@@ -96,7 +96,7 @@ class TestTarsClient(unittest.TestCase):
         mock_response.json.return_value = {
             "data": [
                 {
-                    "lot": "12345",
+                    "lot": "VT12345",
                     "datePrepped": "2023-12-15T12:34:56Z",
                     "viralPrep": {
                         "viralPrepType": {"name": "Crude-SOP#VC002"},
@@ -112,15 +112,15 @@ class TestTarsClient(unittest.TestCase):
             ]
         }
         mock_get.return_value = mock_response
-        result = self.tars_client._get_prep_lot_response("12345")
+        result = self.tars_client._get_prep_lot_response("VT12345")
         expected_url = (
             f"{self.azure_settings.resource}/api/v1/ViralPrepLots"
             f"?order=1&orderBy=id"
             f"&searchFields=lot"
-            f"&search=12345"
+            f"&search=VT12345"
         )
 
-        self.assertEqual(result.json()["data"][0]["lot"], "12345")
+        self.assertEqual(result.json()["data"][0]["lot"], "VT12345")
         mock_get.assert_called_once_with(
             expected_url, headers=self.tars_client._headers
         )

--- a/tests/tars/test_client.py
+++ b/tests/tars/test_client.py
@@ -64,8 +64,7 @@ class TestTarsClient(unittest.TestCase):
             client_id="some_client_id",
             client_secret="some_client_secret",
             scope="some_scope",
-            resource="https://some_resource"
-
+            resource="https://some_resource",
         )
 
         with open(EXAMPLE_PATH, "r") as f:
@@ -89,7 +88,7 @@ class TestTarsClient(unittest.TestCase):
         self.assertEqual(self.tars_client._headers, expected_headers)
 
     @patch("aind_metadata_service.tars.client.requests.get")
-    def test_get_prep_lot_response(self, mock_get):
+    def test_get_prep_lot_response_success(self, mock_get):
         """Tests that client can fetch viral prep lot."""
 
         mock_response = Mock()
@@ -124,6 +123,16 @@ class TestTarsClient(unittest.TestCase):
         self.assertEqual(result.json()["data"][0]["lot"], "12345")
         mock_get.assert_called_once_with(
             expected_url, headers=self.tars_client._headers
+        )
+
+    def test_get_prep_lot_response_failure(self):
+        """Tests that exception is raised as expected"""
+        with self.assertRaises(Exception) as context:
+            self.tars_client._get_prep_lot_response(prep_lot_number="VT")
+
+        self.assertEqual(
+            "The input prep lot VT seems to be incomplete.",
+            str(context.exception),
         )
 
     @patch("aind_metadata_service.tars.client.requests.get")

--- a/tests/tars/test_mapping.py
+++ b/tests/tars/test_mapping.py
@@ -1,4 +1,5 @@
 """Module to test TARS mapping."""
+
 import datetime
 import unittest
 from unittest.mock import MagicMock

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1,4 +1,5 @@
 """Module to test the aind_metadata_service client."""
+
 import pickle
 import unittest
 from unittest import mock


### PR DESCRIPTION
closes #166 

- Adds endpoint for injection_materials in the server
- Filters the raw response from TARS to find exact matches (rather than all lots containing input prep lot number)
- Returns no data response when there are no exact matches or if the input is an empty string
- Adds no_data_response class method to ModelResponse
- Pins pydantic version
- black linter updated to add newlines, so there's a couple non-TARS changes in this PR