### PR TITLE
Feat 189: Validate `subject_id` and parameterize SQL queries

### DIFF
--- a/src/aind_metadata_service/labtracks/client.py
+++ b/src/aind_metadata_service/labtracks/client.py
@@ -128,7 +128,6 @@ class LabTracksClient:
             This is the id in the LabTracks ANIMALS_COMMON table
         """
         if not subject_id.isalnum():
-            # TODO: check if we want to use a new invalid_input_error_response
             return ModelResponse.no_data_found_error_response()
         try:
             query = LabTracksQueries.subject_from_subject_id()
@@ -161,7 +160,6 @@ class LabTracksClient:
             This is the id in the LabTracks Task_Set table
         """
         if not subject_id.isalnum():
-            # TODO: check if we want to use a new invalid_input_error_response
             return ModelResponse.no_data_found_error_response()
         try:
             query = LabTracksQueries.procedures_from_subject_id()

--- a/src/aind_metadata_service/labtracks/client.py
+++ b/src/aind_metadata_service/labtracks/client.py
@@ -127,6 +127,9 @@ class LabTracksClient:
         subject_id: str
             This is the id in the LabTracks ANIMALS_COMMON table
         """
+        if not subject_id.isalnum():
+            # TODO: check if we want to use a new invalid_input_error_response
+            return ModelResponse.no_data_found_error_response()
         try:
             query = LabTracksQueries.subject_from_subject_id()
             session = self.create_session()
@@ -157,6 +160,9 @@ class LabTracksClient:
         subject_id: str
             This is the id in the LabTracks Task_Set table
         """
+        if not subject_id.isalnum():
+            # TODO: check if we want to use a new invalid_input_error_response
+            return ModelResponse.no_data_found_error_response()
         try:
             query = LabTracksQueries.procedures_from_subject_id()
             session = self.create_session()

--- a/src/aind_metadata_service/labtracks/client.py
+++ b/src/aind_metadata_service/labtracks/client.py
@@ -125,12 +125,13 @@ class LabTracksClient:
         Parameters
         ----------
         subject_id: str
+            This is the id in the LabTracks ANIMALS_COMMON table
         """
         try:
-            query = LabTracksQueries.subject_from_subject_id(subject_id)
+            query = LabTracksQueries.subject_from_subject_id()
             session = self.create_session()
             cursor = session.cursor()
-            cursor.execute(query)
+            cursor.execute(query, subject_id)
             column_names = cursor.description
             columns = [column[0].lower() for column in column_names]
             fetched_rows = cursor.fetchall()
@@ -154,12 +155,13 @@ class LabTracksClient:
         Parameters
         ----------
         subject_id: str
+            This is the id in the LabTracks Task_Set table
         """
         try:
-            query = LabTracksQueries.procedures_from_subject_id(subject_id)
+            query = LabTracksQueries.procedures_from_subject_id()
             session = self.create_session()
             cursor = session.cursor()
-            cursor.execute(query)
+            cursor.execute(query, subject_id)
             column_names = cursor.description
             columns = [column[0].lower() for column in column_names]
             fetched_rows = cursor.fetchall()

--- a/src/aind_metadata_service/labtracks/client.py
+++ b/src/aind_metadata_service/labtracks/client.py
@@ -127,7 +127,7 @@ class LabTracksClient:
         subject_id: str
             This is the id in the LabTracks ANIMALS_COMMON table
         """
-        if not subject_id.isalnum():
+        if not subject_id.isnumeric():
             return ModelResponse.no_data_found_error_response()
         try:
             query = LabTracksQueries.subject_from_subject_id()
@@ -159,7 +159,7 @@ class LabTracksClient:
         subject_id: str
             This is the id in the LabTracks Task_Set table
         """
-        if not subject_id.isalnum():
+        if not subject_id.isnumeric():
             return ModelResponse.no_data_found_error_response()
         try:
             query = LabTracksQueries.procedures_from_subject_id()

--- a/src/aind_metadata_service/labtracks/query_builder.py
+++ b/src/aind_metadata_service/labtracks/query_builder.py
@@ -73,7 +73,7 @@ class LabTracksQueries:
             "    ON TS.TASK_TYPE_ID = TT.ID"
             "    INNER JOIN ACUC_PROTOCOL AP "
             "    ON TS.ACUC_LINK_ID = AP.LINK_INDEX"
-            f" WHERE AC.ID=?;"
+            " WHERE AC.ID = ?;"
         )
 
     @staticmethod

--- a/src/aind_metadata_service/labtracks/query_builder.py
+++ b/src/aind_metadata_service/labtracks/query_builder.py
@@ -39,14 +39,10 @@ class LabTracksQueries:
     """Class to hold sql query strings for LabTracks"""
 
     @staticmethod
-    def procedures_from_subject_id(subject_id: str) -> str:
+    def procedures_from_subject_id() -> str:
         """
-        Retrieves the information to populate metadata about subjects.
-
-        Parameters
-        ----------
-        subject_id : str
-            This is the id in the LabTracks Task_Set table
+        Retrieves the information to populate metadata about procedures.
+        Uses ? as a placeholder for the subject_id.
 
         Returns
         -------
@@ -77,18 +73,14 @@ class LabTracksQueries:
             "    ON TS.TASK_TYPE_ID = TT.ID"
             "    INNER JOIN ACUC_PROTOCOL AP "
             "    ON TS.ACUC_LINK_ID = AP.LINK_INDEX"
-            f" WHERE AC.ID={subject_id};"
+            f" WHERE AC.ID=?;"
         )
 
     @staticmethod
-    def subject_from_subject_id(subject_id: str) -> str:
+    def subject_from_subject_id() -> str:
         """
         Retrieves the information to populate metadata about subjects.
-
-        Parameters
-        ----------
-        subject_id : str
-            This is the id in the LabTracks ANIMALS_COMMON table
+        Uses ? as a placeholder for the subject_id.
 
         Returns
         -------
@@ -126,5 +118,5 @@ class LabTracksQueries:
             "    ON AC.GROUP_ID = G.ID"
             "    LEFT OUTER JOIN GROUPS "
             "    ON MATERNAL.GROUP_ID = GROUPS.ID"
-            f" WHERE AC.ID={subject_id};"
+            " WHERE AC.ID = ?;"
         )

--- a/tests/labtracks/test_client.py
+++ b/tests/labtracks/test_client.py
@@ -200,13 +200,15 @@ class TestLabTracksClient(unittest.TestCase):
     def test_id_is_invalid(self, _) -> None:
         """
         Tests that JSONResponse error is returned to client properly
-        when queried subject_id is invalid (not alphanumeric)
+        when queried subject_id is invalid (not numeric).
 
         Returns
         -------
             pass
         """
         invalid_subject_ids = [
+            "",
+            "1234ab",
             "1159!7",
             "115977; DROP TABLE ANIMALS_COMMON",
             "115977; DROP TABLE TASK_SET; --",

--- a/tests/labtracks/test_client.py
+++ b/tests/labtracks/test_client.py
@@ -197,6 +197,33 @@ class TestLabTracksClient(unittest.TestCase):
         self.assertEqual([], procedure_response1.aind_models)
 
     @patch("pyodbc.connect")
+    def test_id_is_invalid(self, _) -> None:
+        """
+        Tests that JSONResponse error is returned to client properly
+        when queried subject_id is invalid (not alphanumeric)
+
+        Returns
+        -------
+            pass
+        """
+        invalid_subject_ids = [
+            "1159!7",
+            "115977; DROP TABLE ANIMALS_COMMON",
+            "115977; DROP TABLE TASK_SET; --",
+        ]
+        for id in invalid_subject_ids:
+            subject_response = self.lb_client.get_subject_info(id)
+            procedure_response = self.lb_client.get_procedures_info(id)
+            self.assertEqual(
+                StatusCodes.NO_DATA_FOUND, subject_response.status_code
+            )
+            self.assertEqual(
+                StatusCodes.NO_DATA_FOUND, procedure_response.status_code
+            )
+            self.assertEqual([], subject_response.aind_models)
+            self.assertEqual([], procedure_response.aind_models)
+
+    @patch("pyodbc.connect")
     def test_get_subject_info_success(self, mock_connect: Mock) -> None:
         """
         Tests that JSONResponse is returned to client properly
@@ -233,7 +260,7 @@ class TestLabTracksClient(unittest.TestCase):
             ]
 
             @staticmethod
-            def execute(_):
+            def execute(_, __):
                 """Mock execute"""
                 return None
 
@@ -317,7 +344,7 @@ class TestLabTracksClient(unittest.TestCase):
             ]
 
             @staticmethod
-            def execute(_):
+            def execute(_, __):
                 """Mock execute"""
                 return None
 
@@ -415,7 +442,7 @@ class TestLabTracksClient(unittest.TestCase):
             ]
 
             @staticmethod
-            def execute(_):
+            def execute(_, __):
                 """Mock execute"""
                 return None
 

--- a/tests/labtracks/test_query_builder.py
+++ b/tests/labtracks/test_query_builder.py
@@ -14,8 +14,7 @@ class TestLabTracksQueryBuilder(unittest.TestCase):
 
     def test_subject_from_species(self):
         """Tests sql string is created correctly."""
-        subject_id = "625464"
-        actual_output = LabTracksQueries.subject_from_subject_id(subject_id)
+        actual_output = LabTracksQueries.subject_from_subject_id()
         expected_output = (
             "SELECT"
             f"    AC.ID AS {SubjectQueryColumns.ID.value},"
@@ -45,14 +44,13 @@ class TestLabTracksQueryBuilder(unittest.TestCase):
             "    ON AC.GROUP_ID = G.ID"
             "    LEFT OUTER JOIN GROUPS "
             "    ON MATERNAL.GROUP_ID = GROUPS.ID"
-            f" WHERE AC.ID={subject_id};"
+            " WHERE AC.ID = ?;"
         )
         self.assertEqual(expected_output, actual_output)
 
     def test_procedures_from_id(self):
         """Tests sql string is created correctly."""
-        subject_id = "625464"
-        actual_output = LabTracksQueries.procedures_from_subject_id(subject_id)
+        actual_output = LabTracksQueries.procedures_from_subject_id()
         expected_output = (
             "SELECT"
             f"    TS.ID AS {TaskSetQueryColumns.TASK_ID.value},"
@@ -75,7 +73,7 @@ class TestLabTracksQueryBuilder(unittest.TestCase):
             "    ON TS.TASK_TYPE_ID = TT.ID"
             "    INNER JOIN ACUC_PROTOCOL AP "
             "    ON TS.ACUC_LINK_ID = AP.LINK_INDEX"
-            f" WHERE AC.ID={subject_id};"
+            " WHERE AC.ID = ?;"
         )
         self.assertEqual(expected_output, actual_output)
 


### PR DESCRIPTION
closes #189
- Added input validation to ensure `subject_id` is alphanumeric with no special characters
- Refactor SQL queries and `cursor.execute()` to use parameterized queries with `?` placeholder to prevent SQL injection attacks
    - pyodbc supports parameterized queries ([docs](https://github.com/mkleehammer/pyodbc/wiki/Getting-started#parameters))
    - db driver will receive query and params separately and ensures the server does not treat params as part of SQL code
- Updated unit tests as appropriate 