### PR TITLE
Feat 60: Add index page and search /subjects UI

### DIFF
--- a/src/aind_metadata_service/server.py
+++ b/src/aind_metadata_service/server.py
@@ -12,6 +12,7 @@ from fastapi.responses import RedirectResponse
 from fastapi.templating import Jinja2Templates
 from starlette.concurrency import run_in_threadpool
 
+from aind_metadata_service import __version__ as SERVICE_VERSION
 from aind_metadata_service.labtracks.client import (
     LabTracksClient,
     LabTracksSettings,
@@ -255,6 +256,7 @@ async def index(request: Request):
         context=(
             {
                 "request": request,
+                "version": SERVICE_VERSION,
             }
         ),
     )

--- a/src/aind_metadata_service/server.py
+++ b/src/aind_metadata_service/server.py
@@ -6,9 +6,10 @@ from aind_metadata_mapper.bergamo.session import BergamoEtl
 from aind_metadata_mapper.bergamo.session import (
     JobSettings as BergamoJobSettings,
 )
-from fastapi import FastAPI
+from fastapi import FastAPI, Request
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import RedirectResponse
+from fastapi.templating import Jinja2Templates
 from starlette.concurrency import run_in_threadpool
 
 from aind_metadata_service.labtracks.client import (
@@ -83,6 +84,11 @@ protocols_smart_sheet_client = SmartSheetClient(
 )
 
 tars_client = TarsClient(azure_settings=tars_settings)
+
+template_directory = os.path.abspath(
+    os.path.join(os.path.dirname(__file__), "templates")
+)
+templates = Jinja2Templates(directory=template_directory)
 
 
 @app.post("/bergamo_session/")
@@ -237,3 +243,18 @@ async def favicon():
     Returns the favicon
     """
     return favicon_path
+
+
+@app.get("/")
+async def index(request: Request):
+    """
+    Returns the index page from templates
+    """
+    return templates.TemplateResponse(
+        name="index.html",
+        context=(
+            {
+                "request": request,
+            }
+        ),
+    )

--- a/src/aind_metadata_service/server.py
+++ b/src/aind_metadata_service/server.py
@@ -249,14 +249,24 @@ async def favicon():
 @app.get("/")
 async def index(request: Request):
     """
-    Returns the index page from templates
+    Returns the index page with search UIs for enabled endpoints (provided template context).
     """
     return templates.TemplateResponse(
         name="index.html",
         context=(
             {
                 "request": request,
-                "version": SERVICE_VERSION,
+                "service_name": "AIND Metadata Service",
+                "service_description": "REST service to retrieve metadata from AIND databases.", # optional
+                "service_version": SERVICE_VERSION, # optional
+                "endpoints": [
+                    {
+                        "endpoint": "subject",
+                        "description": "Retrieve subject metadata from Labtracks server", # optional
+                        "parameter": "subject_id",
+                        "parameter_label": "Subject ID" # optional
+                    }
+                ]
             }
         ),
     )

--- a/src/aind_metadata_service/server.py
+++ b/src/aind_metadata_service/server.py
@@ -249,24 +249,28 @@ async def favicon():
 @app.get("/")
 async def index(request: Request):
     """
-    Returns the index page with search UIs for enabled endpoints (provided template context).
+    Returns the index page with search UIs for enabled endpoints.
     """
     return templates.TemplateResponse(
         name="index.html",
         context=(
             {
-                "request": request,
-                "service_name": "AIND Metadata Service",
-                "service_description": "REST service to retrieve metadata from AIND databases.", # optional
-                "service_version": SERVICE_VERSION, # optional
+                "request": request,  # required
+                "service_name": "AIND Metadata Service",  # required
+                "service_description": (
+                    "REST service to retrieve metadata from AIND databases."
+                ),
+                "service_version": SERVICE_VERSION,
                 "endpoints": [
                     {
-                        "endpoint": "subject",
-                        "description": "Retrieve subject metadata from Labtracks server", # optional
-                        "parameter": "subject_id",
-                        "parameter_label": "Subject ID" # optional
-                    }
-                ]
+                        "endpoint": "subject",  # required
+                        "description": (
+                            "Retrieve subject metadata from Labtracks server"
+                        ),
+                        "parameter": "subject_id",  # required
+                        "parameter_label": "Subject ID",
+                    },
+                ],
             }
         ),
     )

--- a/src/aind_metadata_service/templates/index.html
+++ b/src/aind_metadata_service/templates/index.html
@@ -63,6 +63,10 @@
 <body>
   <div class="header">
     <h1>AIND Metadata Service</h1>
+    <span>
+      REST service to retrieve metadata from AIND databases.
+      {% if version %} Version {{ version }}{% endif %}
+    </span>
   </div>
   <div>
     <h2>Subject</h2>

--- a/src/aind_metadata_service/templates/index.html
+++ b/src/aind_metadata_service/templates/index.html
@@ -4,7 +4,7 @@
 <head>
   <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.6.4/jquery.min.js"></script>
   <meta charset="UTF-8">
-  <title>AIND Metadata Service</title>
+  <title>{{ service_name }}</title>
   <style>
     body {
       font-family: arial, sans-serif;
@@ -54,7 +54,7 @@
     #user-message.error {
       color: red;
     }
-    .endpoint, pre {
+    .path, pre {
       font-family: monospace;
       border: 1px solid #dddddd;
       background-color: #f5f5f5;
@@ -67,7 +67,7 @@
       min-width: 300px;
       overflow: auto;
     }
-    .endpoint {
+    .path {
       margin-left: 10px !important;
       padding: 5px;
     }
@@ -86,23 +86,25 @@
 
 <body>
   <div class="header">
-    <h1>AIND Metadata Service</h1>
+    <h1>{{ service_name }}</h1>
     <span>
-      REST service to retrieve metadata from AIND databases.
-      {% if version %} Version {{ version }}{% endif %}
+      {{ service_description }}
+      {% if service_version %} Version {{ service_version }}{% endif %}
     </span>
   </div>
+  {% for e in endpoints if e.endpoint and e.parameter %}
   <div>
     <div class="container">
-      <div class="heading">Subject<span class="endpoint">/subject/{subject_id}</span></div>
-      <p>Retrieve subject metadata from Labtracks server</p>
-      <label for="subject-id">Subject ID:</label>
-      <input type="text" id="subject-id" size="6" placeholder="subject_id" />
+      <div class="heading">{{ e.endpoint|title }}
+        <span class="path">{{ "/%s/{%s}"|format(e.endpoint, e.parameter) }}</span>
+      </div>
+      <p>{{ e.description }}</p>
+      <label for="param-id-{{ e.endpoint }}">{{ e.parameter_label or e.parameter }}:</label>
+      <input type="text" id="param-id-{{ e.endpoint }}" size="6" placeholder="{{ e.parameter }}" />
     </div>
+    <button id="search" type="button" class="primary" onclick="queryEndpoint('{{ e.endpoint }}')">Search</button>
   </div>
-  <div>
-    <button id="search" type="button" class="primary" onclick="querySubject()">Search</button>
-  </div>
+  {% endfor %}
   <div>
     <div id="user-message"></div>
     <div id="response" class="container" hidden>
@@ -141,10 +143,10 @@
       const viewOrHide = $("#response-raw-div").is(":visible") ? "Hide" : "View";
       $("#toggle-raw").text(`${viewOrHide} raw response`);
     };
-    querySubject = function () {
-      let subjectID = $("#subject-id").val();
+    queryEndpoint = function (endpoint) {
+      let parameter = $(`#param-id-${endpoint}`).val();
       $.ajax({
-        url: `http://aind-metadata-service-dev/subject/${subjectID}`,
+        url: `/${endpoint}/${parameter}`,
         type: "GET",
         beforeSend: function () {
           displayPendingUI();

--- a/src/aind_metadata_service/templates/index.html
+++ b/src/aind_metadata_service/templates/index.html
@@ -48,11 +48,10 @@
         &:hover { background-color: #aab1dc; }
       }
     }
-    #user-message.success {
-      color: green;
-    }
-    #user-message.error {
-      color: red;
+    #user-message {
+      &.pending { color: darkorange; }
+      &.success { color: green; }
+      &.error { color: red; }
     }
     .path, pre {
       font-family: monospace;
@@ -118,21 +117,21 @@
 
   <script>
     displayPendingUI = function () {
-      $("#user-message").removeClass("success error");
-      $("#user-message").html("Searching.... Please do not refresh or re-submit.");    
+      $("#user-message").removeClass("success error").addClass("pending");
+      $("#user-message").html("Searching.... Please do not refresh or re-submit.");
       for (let id of ["message", "data", "raw"]) {
         $(`#response-${id}`).html("");
       }
       $("#response").hide();
     };
-    displayResponseUI = function (isError, response, statusCode, statusText) {      
+    displayResponseUI = function (isError, response, statusCode, statusText) {
       const responseText = {
         "user-message"    : `Search returned ${statusText} (Status ${statusCode}).`,
-        "response-message": response.message,
-        "response-data"   : JSON.stringify(response.data, null, 2),
+        "response-message": response?.message,
+        "response-data"   : JSON.stringify(response?.data, null, 2),
         "response-raw"    : JSON.stringify(response, null, 2)
       }
-      $("#user-message").addClass(isError ? "error" : "success");
+      $("#user-message").removeClass("pending").addClass(isError ? "error" : "success");
       Object.keys(responseText).forEach((id) => {
         $(`#${id}`).html(responseText[id]);
       });
@@ -155,7 +154,12 @@
           displayResponseUI(false, data, xhr.status, xhr.statusText);
         },
         error: function (data) {
-          displayResponseUI(true, data.responseJSON, data.status, data.statusText);
+          displayResponseUI(
+            true, 
+            data.responseJSON ?? data.responseText ?? data,
+            data.status,
+            data.statusText
+          );
         }
       });
     };

--- a/src/aind_metadata_service/templates/index.html
+++ b/src/aind_metadata_service/templates/index.html
@@ -7,21 +7,61 @@
   <style>
     body {
       font-family: arial, sans-serif;
-    }
-    #header {
-      background-color: #E8EAF6;
-      padding: 20px;
-      border-radius: 6px;
+      .header {
+        background-color: #E8EAF6;
+        padding: 20px;
+        border-radius: 6px;
+      }
+      .header~div, input {
+        margin: 10px;
+      }
     }
     h1 {
       color: #3F51B5;
+    }
+    input {
+      padding: 8px 20px;
+      border: 1px solid #5065df;
+      border-radius: 6px;
+      background-color: #E8EAF6;
+      &:focus {
+        outline: none;
+        border-width: 2px;
+      }
+    }
+    button {
+      border: none;
+      border-radius: 6px;
+      color: #ffffff;
+      padding: 8px 20px;
+      font-size: medium;
+      background-color: #5065df;
+      cursor: pointer;
+      &:hover {
+        background-color: #3f51b5;
+      }
     }
   </style>
 </head>
 
 <body>
-  <div id="header">
+  <div class="header">
     <h1>AIND Metadata Service</h1>
+  </div>
+  <div>
+    <h2>Subject</h2>
+    <span>Retrieve subject metadata from Labtracks server</span>
+    <div>
+      <label for="subject-id">Subject ID:</label>
+      <input type="text" id="subject-id" size="6" placeholder="subject_id" />
+    </div>
+  </div>
+  <div>
+    <button id="search" type="button">Search</button>
+  </div>
+  <div>
+    <div id="message"></div>
+    <pre id="json" hidden></pre>
   </div>
 </body>
 

--- a/src/aind_metadata_service/templates/index.html
+++ b/src/aind_metadata_service/templates/index.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+  <meta charset="UTF-8">
+  <title>AIND Metadata Service</title>
+  <style>
+    body {
+      font-family: arial, sans-serif;
+    }
+    #header {
+      background-color: #E8EAF6;
+      padding: 20px;
+      border-radius: 6px;
+    }
+    h1 {
+      color: #3F51B5;
+    }
+  </style>
+</head>
+
+<body>
+  <div id="header">
+    <h1>AIND Metadata Service</h1>
+  </div>
+</body>
+
+</html>

--- a/src/aind_metadata_service/templates/index.html
+++ b/src/aind_metadata_service/templates/index.html
@@ -16,6 +16,10 @@
       .header~div, input {
         margin: 10px;
       }
+      div, input, button, label, pre, .endpoint {
+        margin: 5px;
+        border-radius: 6px;
+      }
     }
     h1 {
       color: #3F51B5;
@@ -23,7 +27,6 @@
     input {
       padding: 8px 20px;
       border: 1px solid #5065df;
-      border-radius: 6px;
       background-color: #E8EAF6;
       &:focus {
         outline: none;
@@ -32,30 +35,51 @@
     }
     button {
       border: none;
-      border-radius: 6px;
-      color: #ffffff;
       padding: 8px 20px;
-      font-size: medium;
-      background-color: #5065df;
       cursor: pointer;
-      &:hover {
-        background-color: #3f51b5;
+      &.primary {
+        font-size: medium;
+        color: #ffffff;
+        background-color: #5065df;
+        &:hover { background-color: #3f51b5; }
+      }
+      &.secondary {
+        background-color: #c0c7f7;
+        &:hover { background-color: #aab1dc; }
       }
     }
-    #message.success {
+    #user-message.success {
       color: green;
     }
-    #message.error {
+    #user-message.error {
       color: red;
     }
-    #json {
-      padding: 10px;
+    .endpoint, pre {
+      font-family: monospace;
       border: 1px solid #dddddd;
-      border-radius: 6px;
       background-color: #f5f5f5;
-      max-width: 700px;
-      max-height: 400px;
+      font-size: small;
+    }
+    pre {
+      padding: 10px;
+      max-width: 80vw;
+      max-height: 50vh;
+      min-width: 300px;
       overflow: auto;
+    }
+    .endpoint {
+      margin-left: 10px !important;
+      padding: 5px;
+    }
+    .container {
+      padding: 15px;
+      border: 1px dashed #dddddd;
+      width: fit-content;
+      .heading {
+        font-size: x-large;
+        font-weight: bold;
+        margin-bottom: 10px;
+      }
     }
   </style>
 </head>
@@ -69,56 +93,67 @@
     </span>
   </div>
   <div>
-    <h2>Subject</h2>
-    <span>Retrieve subject metadata from Labtracks server</span>
-    <div>
+    <div class="container">
+      <div class="heading">Subject<span class="endpoint">/subject/{subject_id}</span></div>
+      <p>Retrieve subject metadata from Labtracks server</p>
       <label for="subject-id">Subject ID:</label>
       <input type="text" id="subject-id" size="6" placeholder="subject_id" />
     </div>
   </div>
   <div>
-    <button id="search" type="button" onclick="querySubject()">Search</button>
+    <button id="search" type="button" class="primary" onclick="querySubject()">Search</button>
   </div>
   <div>
-    <div id="message"></div>
-    <pre id="json" hidden></pre>
+    <div id="user-message"></div>
+    <div id="response" class="container" hidden>
+      <div class="heading">Response</div>
+      <div>Message:<pre id="response-message"></pre></div>
+      <div>Data:<pre id="response-data"></pre></div>
+      <div id="response-raw-div" hidden>Raw Response:<pre id="response-raw"></pre></div>
+      <button id="toggle-raw" type="button" class="secondary" onclick="toggleViewRawResponse()">View raw response</button>
+    </div>
   </div>
 
   <script>
-    const msgTypes = {
-      "searchPending": "Searching.... Please do not refresh or re-submit.",
-      "searchSuccess": "Search returned success.",
-      "searchError": "Search returned errors."
-    }
-    setMessage = function (msgType) {
-      $("#message").removeClass("success");
-      $("#message").removeClass("error");
-      $("#message").html(msgType);
-      if (msgType == msgTypes.searchSuccess) {
-        $("#message").addClass("success");
-      } else if (msgType == msgTypes.searchError) {
-        $("#message").addClass("error");
+    displayPendingUI = function () {
+      $("#user-message").removeClass("success error");
+      $("#user-message").html("Searching.... Please do not refresh or re-submit.");    
+      for (let id of ["message", "data", "raw"]) {
+        $(`#response-${id}`).html("");
       }
+      $("#response").hide();
+    };
+    displayResponseUI = function (isError, response, statusCode, statusText) {      
+      const responseText = {
+        "user-message"    : `Search returned ${statusText} (Status ${statusCode}).`,
+        "response-message": response.message,
+        "response-data"   : JSON.stringify(response.data, null, 2),
+        "response-raw"    : JSON.stringify(response, null, 2)
+      }
+      $("#user-message").addClass(isError ? "error" : "success");
+      Object.keys(responseText).forEach((id) => {
+        $(`#${id}`).html(responseText[id]);
+      });
+      $("#response").show();
+    };
+    toggleViewRawResponse = function () {
+      $("#response-raw-div").toggle();
+      const viewOrHide = $("#response-raw-div").is(":visible") ? "Hide" : "View";
+      $("#toggle-raw").text(`${viewOrHide} raw response`);
     };
     querySubject = function () {
       let subjectID = $("#subject-id").val();
       $.ajax({
-        url: `/subject/${subjectID}`,
+        url: `http://aind-metadata-service-dev/subject/${subjectID}`,
         type: "GET",
         beforeSend: function () {
-          setMessage(msgTypes.searchPending);
-          $("#json").html("");
-          $("#json").hide();
+          displayPendingUI();
         },
-        success: function (data) {
-          setMessage(msgTypes.searchSuccess);
-          $("#json").show();
-          $("#json").html(JSON.stringify(data, null, 2));
+        success: function (data, status, xhr) {
+          displayResponseUI(false, data, xhr.status, xhr.statusText);
         },
         error: function (data) {
-          setMessage(msgTypes.searchError);
-          $("#json").show();
-          $("#json").html(JSON.stringify(data, null, 2));
+          displayResponseUI(true, data.responseJSON, data.status, data.statusText);
         }
       });
     };

--- a/src/aind_metadata_service/templates/index.html
+++ b/src/aind_metadata_service/templates/index.html
@@ -2,6 +2,7 @@
 <html>
 
 <head>
+  <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.6.4/jquery.min.js"></script>
   <meta charset="UTF-8">
   <title>AIND Metadata Service</title>
   <style>
@@ -41,6 +42,21 @@
         background-color: #3f51b5;
       }
     }
+    #message.success {
+      color: green;
+    }
+    #message.error {
+      color: red;
+    }
+    #json {
+      padding: 10px;
+      border: 1px solid #dddddd;
+      border-radius: 6px;
+      background-color: #f5f5f5;
+      max-width: 700px;
+      max-height: 400px;
+      overflow: auto;
+    }
   </style>
 </head>
 
@@ -57,12 +73,52 @@
     </div>
   </div>
   <div>
-    <button id="search" type="button">Search</button>
+    <button id="search" type="button" onclick="querySubject()">Search</button>
   </div>
   <div>
     <div id="message"></div>
     <pre id="json" hidden></pre>
   </div>
+
+  <script>
+    const msgTypes = {
+      "searchPending": "Searching.... Please do not refresh or re-submit.",
+      "searchSuccess": "Search returned success.",
+      "searchError": "Search returned errors."
+    }
+    setMessage = function (msgType) {
+      $("#message").removeClass("success");
+      $("#message").removeClass("error");
+      $("#message").html(msgType);
+      if (msgType == msgTypes.searchSuccess) {
+        $("#message").addClass("success");
+      } else if (msgType == msgTypes.searchError) {
+        $("#message").addClass("error");
+      }
+    };
+    querySubject = function () {
+      let subjectID = $("#subject-id").val();
+      $.ajax({
+        url: `/subject/${subjectID}`,
+        type: "GET",
+        beforeSend: function () {
+          setMessage(msgTypes.searchPending);
+          $("#json").html("");
+          $("#json").hide();
+        },
+        success: function (data) {
+          setMessage(msgTypes.searchSuccess);
+          $("#json").show();
+          $("#json").html(JSON.stringify(data, null, 2));
+        },
+        error: function (data) {
+          setMessage(msgTypes.searchError);
+          $("#json").show();
+          $("#json").html(JSON.stringify(data, null, 2));
+        }
+      });
+    };
+  </script>
 </body>
 
 </html>

--- a/src/aind_metadata_service/templates/index.html
+++ b/src/aind_metadata_service/templates/index.html
@@ -9,20 +9,22 @@
     body {
       font-family: arial, sans-serif;
       .header {
+        position: fixed;
+        top: 0;
+        left: 0;
+        right: 0;
+        height: 120px;
         background-color: #E8EAF6;
+        padding-left: 40px;
+        overflow: hidden;
+        border-radius: 6px;
+        h1 { color: #3F51B5; }
+      }
+      .main {
+        margin-top: 120px;
         padding: 20px;
-        border-radius: 6px;
+        div, input, button, label { border-radius: 6px; }
       }
-      .header~div, input {
-        margin: 10px;
-      }
-      div, input, button, label, pre, .endpoint {
-        margin: 5px;
-        border-radius: 6px;
-      }
-    }
-    h1 {
-      color: #3F51B5;
     }
     input {
       padding: 8px 20px;
@@ -34,6 +36,7 @@
       }
     }
     button {
+      margin: 20px 0px;
       border: none;
       padding: 8px 20px;
       cursor: pointer;
@@ -58,6 +61,7 @@
       border: 1px solid #dddddd;
       background-color: #f5f5f5;
       font-size: small;
+      border-radius: 6px;
     }
     pre {
       padding: 10px;
@@ -67,10 +71,11 @@
       overflow: auto;
     }
     .path {
-      margin-left: 10px !important;
+      margin-left: 10px;
       padding: 5px;
     }
     .container {
+      margin: 10px 0px;
       padding: 15px;
       border: 1px dashed #dddddd;
       width: fit-content;
@@ -91,27 +96,29 @@
       {% if service_version %} Version {{ service_version }}{% endif %}
     </span>
   </div>
-  {% for e in endpoints if e.endpoint and e.parameter %}
-  <div>
-    <div class="container">
-      <div class="heading">{{ e.endpoint|title }}
-        <span class="path">{{ "/%s/{%s}"|format(e.endpoint, e.parameter) }}</span>
+  <div class="main">
+    {% for e in endpoints if e.endpoint and e.parameter %}
+    <div>
+      <div class="container">
+        <div class="heading">{{ e.endpoint|title }}
+          <span class="path">{{ "/%s/{%s}"|format(e.endpoint, e.parameter) }}</span>
+        </div>
+        <p>{{ e.description }}</p>
+        <label for="param-id-{{ e.endpoint }}">{{ e.parameter_label or e.parameter }}:</label>
+        <input type="text" id="param-id-{{ e.endpoint }}" size="6" placeholder="{{ e.parameter }}" />
       </div>
-      <p>{{ e.description }}</p>
-      <label for="param-id-{{ e.endpoint }}">{{ e.parameter_label or e.parameter }}:</label>
-      <input type="text" id="param-id-{{ e.endpoint }}" size="6" placeholder="{{ e.parameter }}" />
+      <button id="search" type="button" class="primary" onclick="queryEndpoint('{{ e.endpoint }}')">Search</button>
     </div>
-    <button id="search" type="button" class="primary" onclick="queryEndpoint('{{ e.endpoint }}')">Search</button>
-  </div>
-  {% endfor %}
-  <div>
-    <div id="user-message"></div>
-    <div id="response" class="container" hidden>
-      <div class="heading">Response</div>
-      <div>Message:<pre id="response-message"></pre></div>
-      <div>Data:<pre id="response-data"></pre></div>
-      <div id="response-raw-div" hidden>Raw Response:<pre id="response-raw"></pre></div>
-      <button id="toggle-raw" type="button" class="secondary" onclick="toggleViewRawResponse()">View raw response</button>
+    {% endfor %}
+    <div>
+      <div id="user-message"></div>
+      <div id="response" class="container" hidden>
+        <div class="heading">Response</div>
+        <div>Message:<pre id="response-message"></pre></div>
+        <div>Data:<pre id="response-data"></pre></div>
+        <div id="response-raw-div" hidden>Raw Response:<pre id="response-raw"></pre></div>
+        <button id="toggle-raw" type="button" class="secondary" onclick="toggleViewRawResponse()">View raw response</button>
+      </div>
     </div>
   </div>
 
@@ -155,7 +162,7 @@
         },
         error: function (data) {
           displayResponseUI(
-            true, 
+            true,
             data.responseJSON ?? data.responseText ?? data,
             data.status,
             data.statusText


### PR DESCRIPTION
closes #60 
- Added home page `index.html` to be loaded at http://aind-metadata-service/
    - Uses Jinja2Template to render with provided context for service (name, description, version) and enabled endpoints (endpoint, description, parameters)
- User can query subjects endpoint by providing a `subject_id` and clicking the "Search" button.
    - Query status (including when pending) and response are displayed below. The response is first parsed for status, message, and data.
    - The raw response json can also optionally be viewed by clicking the "View raw response" button
    
----
![pending](https://github.com/AllenNeuralDynamics/aind-metadata-service/assets/46795546/3b8ebecc-32cf-4565-a927-4da072dc5335)
----
![result_success](https://github.com/AllenNeuralDynamics/aind-metadata-service/assets/46795546/643871a4-d98a-4792-b495-d21d43940e23)
----
![result_error_406](https://github.com/AllenNeuralDynamics/aind-metadata-service/assets/46795546/917ba5e3-f0d1-4c76-bfc9-c1163d3b7304)
----
![result_error_500](https://github.com/AllenNeuralDynamics/aind-metadata-service/assets/46795546/f0fea805-6c70-4d8b-b114-5cbd8bd3f77b)
