### PR TITLE
hot fix: tars status handling

### DIFF
--- a/src/aind_metadata_service/tars/mapping.py
+++ b/src/aind_metadata_service/tars/mapping.py
@@ -253,11 +253,19 @@ class TarsResponseHandler:
                             == StatusCodes.DB_RESPONDED.value
                             or tars_response.status_code
                             == StatusCodes.VALID_DATA.value
+                            or tars_response.status_code
+                            == StatusCodes.INVALID_DATA.value
                         ):
                             data = json.loads(tars_response.body)["data"]
                             procedure.injection_materials = [
                                 ViralMaterial(**data)
                             ]
+                        elif(
+                            tars_response.status_code
+                            == StatusCodes.NO_DATA_FOUND.value
+                        ):
+                            procedure.injection_materials = []
+                            pass
                         else:
                             procedure.injection_materials = []
                             status_code = StatusCodes.MULTI_STATUS

--- a/tests/tars/test_mapping.py
+++ b/tests/tars/test_mapping.py
@@ -376,6 +376,31 @@ class TestTarsResponseHandler(unittest.TestCase):
         )
         self.assertEqual(merged_response.status_code, StatusCodes.MULTI_STATUS)
 
+    def test_integrate_injection_materials_no_data(self):
+        """Tests that injection materials are integrated into
+        procedures response as expected"""
+        tars_response = ModelResponse(
+            aind_models=[],
+            status_code=StatusCodes.NO_DATA_FOUND,
+        )
+        tars_mapping = {
+            "12345": tars_response.map_to_json_response(),
+        }
+        inj1 = NanojectInjection.model_construct(
+            injection_materials=[ViralMaterial.model_construct(name="12345")]
+        )
+        surgery = Surgery.model_construct(procedures=[inj1])
+        procedures_response = ModelResponse(
+            aind_models=[
+                Procedures(subject_id="12345", subject_procedures=[surgery])
+            ],
+            status_code=StatusCodes.DB_RESPONDED,
+        )
+        merged_response = self.handler.integrate_injection_materials(
+            response=procedures_response, tars_mapping=tars_mapping
+        )
+        self.assertEqual(merged_response.status_code, StatusCodes.DB_RESPONDED)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
closes #205 

Adds checks for Invalid Data and No Data Found for the tars endpoint. 
- If it's invalid, it'll still integrate that data into the procedures response and validate as expected. 
- If the tars endpoint returns a no data found error, it'll pass. 