### PR TITLE
Feat 224 project names

### DIFF
--- a/src/aind_metadata_service/server.py
+++ b/src/aind_metadata_service/server.py
@@ -194,6 +194,21 @@ async def retrieve_funding(project_name, pickle: bool = False):
         return model_response.map_to_json_response()
 
 
+@app.get("/project_names")
+async def retrieve_project_names():
+    """Retrieves funding information from smartsheet"""
+
+    # TODO: We can probably cache the response if it's 200
+    smart_sheet_response = await run_in_threadpool(
+        funding_smart_sheet_client.get_sheet
+    )
+    mapper = FundingMapper(
+        smart_sheet_response=smart_sheet_response, input_id=""
+    )
+    json_response = mapper.get_project_names()
+    return json_response
+
+
 @app.get("/subject/{subject_id}")
 async def retrieve_subject(subject_id, pickle: bool = False):
     """

--- a/src/aind_metadata_service/smartsheet/funding/mapping.py
+++ b/src/aind_metadata_service/smartsheet/funding/mapping.py
@@ -7,6 +7,7 @@ from typing import List, Optional, Union
 from aind_data_schema.core.data_description import Funding
 from aind_data_schema.models.organizations import Organization
 from pydantic import ValidationError
+from starlette.responses import JSONResponse
 
 from aind_metadata_service.client import StatusCodes
 from aind_metadata_service.response_handler import ModelResponse
@@ -128,3 +129,22 @@ class FundingMapper(SmartSheetMapper):
         except Exception as e:
             logging.error(repr(e))
             return ModelResponse.internal_server_error_response()
+
+    def get_project_names(self) -> JSONResponse:
+        """Get list of project names from funding sheet"""
+        try:
+            project_names = []
+            for row in self.model.rows:
+                row_dict = self.map_row_to_dict(row)
+                project_name = row_dict.get(FundingColumnNames.PROJECT_NAME)
+                if project_name is not None:
+                    project_names.append(project_name)
+            return JSONResponse(
+                status_code=200,
+                content=({"message": "Success", "data": project_names}),
+            )
+        except Exception as e:
+            return JSONResponse(
+                status_code=500,
+                content=({"message": f"Error: {e}", "data": None}),
+            )

--- a/src/aind_metadata_service/smartsheet/funding/mapping.py
+++ b/src/aind_metadata_service/smartsheet/funding/mapping.py
@@ -133,15 +133,17 @@ class FundingMapper(SmartSheetMapper):
     def get_project_names(self) -> JSONResponse:
         """Get list of project names from funding sheet"""
         try:
-            project_names = []
+            project_names = set()
             for row in self.model.rows:
                 row_dict = self.map_row_to_dict(row)
                 project_name = row_dict.get(FundingColumnNames.PROJECT_NAME)
                 if project_name is not None:
-                    project_names.append(project_name)
+                    project_names.add(project_name)
             return JSONResponse(
                 status_code=200,
-                content=({"message": "Success", "data": project_names}),
+                content=(
+                    {"message": "Success", "data": sorted(list(project_names))}
+                ),
             )
         except Exception as e:
             return JSONResponse(


### PR DESCRIPTION
Closes #224 

- Adds endpoint to retrieve project names in funding sheet
- Endpoint looks like: `http://aind-metadata-service/project_names`
- Response looks like:
```
{
  "message": "Success",
  "data": [
    "AIND Viral Genetic Tools",
    "Behavior Platform",
    "Brain Computer Interface",
    "Cell Type LUT",
    "Cognitive flexibility in patch foraging",
    "Discovery-Brain Wide Circuit Dynamics",
    "Discovery-Neuromodulator circuit dynamics during foraging",
    "Dynamic Routing",
    "Ephys Platform",
    "Force Foraging",
    "Information seeking in partially observable environments",
    "Learning mFISH/V1omFISH",
    "MSMA Platform",
    "Medulla",
    "Neurobiology of Action",
    "OpenScope",
    "Ophys Platform - FP and indicator testing",
    "Ophys Platform - SLAP2",
    "Single-neuron computations within brain-wide circuits (SCBC)",
    "Thalamus in the middle"
  ]
}
```