### PR TITLE
Fix 260 tars strip

### DIFF
--- a/src/aind_metadata_service/tars/mapping.py
+++ b/src/aind_metadata_service/tars/mapping.py
@@ -223,7 +223,7 @@ class TarsResponseHandler:
                         and procedure.injection_materials
                     ):
                         virus_strains = [
-                            getattr(material, "name")
+                            getattr(material, "name").strip(" \t\n\r")
                             for material in procedure.injection_materials
                         ]
                         viruses.extend(virus_strains)
@@ -253,8 +253,11 @@ class TarsResponseHandler:
                             if isinstance(
                                 injection_material, ViralMaterial
                             ) and hasattr(injection_material, "name"):
-                                virus_strain = injection_material.name
+                                virus_strain = injection_material.name.strip(
+                                    " \t\n\r"
+                                )
                                 tars_response = tars_mapping.get(virus_strain)
+                                print(tars_response)
                                 if (
                                     tars_response.status_code
                                     == StatusCodes.DB_RESPONDED.value

--- a/src/aind_metadata_service/tars/mapping.py
+++ b/src/aind_metadata_service/tars/mapping.py
@@ -223,7 +223,7 @@ class TarsResponseHandler:
                         and procedure.injection_materials
                     ):
                         virus_strains = [
-                            getattr(material, "name").strip(" \t\n\r")
+                            getattr(material, "name").strip()
                             for material in procedure.injection_materials
                         ]
                         viruses.extend(virus_strains)
@@ -253,9 +253,7 @@ class TarsResponseHandler:
                             if isinstance(
                                 injection_material, ViralMaterial
                             ) and hasattr(injection_material, "name"):
-                                virus_strain = injection_material.name.strip(
-                                    " \t\n\r"
-                                )
+                                virus_strain = injection_material.name.strip()
                                 tars_response = tars_mapping.get(virus_strain)
                                 if (
                                     tars_response.status_code

--- a/src/aind_metadata_service/tars/mapping.py
+++ b/src/aind_metadata_service/tars/mapping.py
@@ -257,7 +257,6 @@ class TarsResponseHandler:
                                     " \t\n\r"
                                 )
                                 tars_response = tars_mapping.get(virus_strain)
-                                print(tars_response)
                                 if (
                                     tars_response.status_code
                                     == StatusCodes.DB_RESPONDED.value

--- a/tests/tars/test_mapping.py
+++ b/tests/tars/test_mapping.py
@@ -28,10 +28,10 @@ class TestTarsResponseHandler(unittest.TestCase):
 
     handler = TarsResponseHandler()
     inj1 = NanojectInjection.model_construct(
-        injection_materials=[ViralMaterial.model_construct(name="12345")]
+        injection_materials=[ViralMaterial.model_construct(name="\n12345 ")]
     )
     inj2 = NanojectInjection.model_construct(
-        injection_materials=[ViralMaterial.model_construct(name="67890\t")]
+        injection_materials=[ViralMaterial.model_construct(name=" 67890\t")]
     )
     surgery = Surgery.model_construct(procedures=[inj1, inj2])
     procedures_response = ModelResponse(

--- a/tests/tars/test_mapping.py
+++ b/tests/tars/test_mapping.py
@@ -31,7 +31,7 @@ class TestTarsResponseHandler(unittest.TestCase):
         injection_materials=[ViralMaterial.model_construct(name="12345")]
     )
     inj2 = NanojectInjection.model_construct(
-        injection_materials=[ViralMaterial.model_construct(name="67890")]
+        injection_materials=[ViralMaterial.model_construct(name="67890\t")]
     )
     surgery = Surgery.model_construct(procedures=[inj1, inj2])
     procedures_response = ModelResponse(


### PR DESCRIPTION
closes #260 

Adds strip to get_virus_strains and in integration method to remove whitespaces, or special characters (such as  "\t") from virus strains pulled from NSB and used to query TARS. Does not handle case sensitive queries in TARS

