### PR TITLE
Fix: Handle Viralmaterial Breaks

### DIFF
--- a/src/aind_metadata_service/sharepoint/las2020/mapping.py
+++ b/src/aind_metadata_service/sharepoint/las2020/mapping.py
@@ -118,6 +118,9 @@ class MappedLASList:
     SCIENTIFIC_NOTATION_REGEX = re.compile(
         r"^[-+]?\d*\.?\d+[eE][-+]?\d+(?![\d.])"
     )
+    TITER_WITH_UNIT_REGEX = re.compile(
+        r"(\d+\.?\d*)\s*gc/ml"
+    )
 
     def __init__(self, las: LASList):
         """Class constructor"""
@@ -175,10 +178,19 @@ class MappedLASList:
                 name=dose_sub,
             )
 
-    def _is_titer(self, titer_str: str) -> bool:
+    def _is_scientific_notation(self, titer_str: str) -> bool:
         """Checks whether titer field is in scientific notation."""
         return bool(re.search(self.SCIENTIFIC_NOTATION_REGEX, titer_str))
-
+    
+    def _parse_titer(self, titer_str: str):
+        """"""
+        if self._is_scientific_notation(titer_str):
+            titer = re.search(
+                self.SCIENTIFIC_NOTATION_REGEX,
+                titer_str,
+            ).group(0)
+        # TODO: check if is titer with unit
+            
     @property
     def aind_accommodation_comment(self) -> Optional[str]:
         """Maps accommodation_comment to aind model"""
@@ -2139,7 +2151,7 @@ class MappedLASList:
         viral_materials = []
         for material in injectable_materials:
             # Use prep_lot_id in name for tars query
-            if self._is_titer(material.titer):
+            if self._is_scientific_notation(material.titer):
                 titer = re.search(
                     self.SCIENTIFIC_NOTATION_REGEX,
                     material.titer,

--- a/src/aind_metadata_service/sharepoint/las2020/mapping.py
+++ b/src/aind_metadata_service/sharepoint/las2020/mapping.py
@@ -183,29 +183,24 @@ class MappedLASList:
         """Checks whether titer field is in titer with unit format."""
         return bool(re.search(self.VALUE_WITH_UNIT_REGEX, value_str))
 
-    def _parse_titer_str(self, titer_str: Optional[str]) -> Optional[float]:
+    def _parse_titer_str(self, titer_str: str) -> Optional[float]:
         """Parse string representation of titer into float."""
-        if titer_str is None:
-            return None
-        # Check if the string is a valid float or integer format
-        stripped_str = titer_str.strip()
-        if re.match(self.INTEGER_REGEX, stripped_str):
-            return int(float(stripped_str))
+        if re.match(self.INTEGER_REGEX, titer_str):
+            return int(float(titer_str))
         return None
 
     def _parse_titer(self, titer_str: Optional[str]) -> Optional[tuple]:
         """Parses titer field to integer."""
         unit = "gc/mL"  # default unit
-
         if titer_str is None:
             return None, unit
 
         titer_str = titer_str.strip()
-
         numeric_value = self._parse_titer_str(titer_str)
         if numeric_value is not None:
             return numeric_value, unit
 
+        titer_str = titer_str.strip()
         # If the string matches scientific notation
         if self._is_scientific_notation(titer_str):
             titer = float(

--- a/src/aind_metadata_service/tars/mapping.py
+++ b/src/aind_metadata_service/tars/mapping.py
@@ -225,6 +225,7 @@ class TarsResponseHandler:
                         virus_strains = [
                             getattr(material, "name").strip()
                             for material in procedure.injection_materials
+                            if getattr(material, "name", None)
                         ]
                         viruses.extend(virus_strains)
         return viruses
@@ -252,7 +253,7 @@ class TarsResponseHandler:
                         ):
                             if isinstance(
                                 injection_material, ViralMaterial
-                            ) and hasattr(injection_material, "name"):
+                            ) and getattr(injection_material, "name", None):
                                 virus_strain = injection_material.name.strip()
                                 tars_response = tars_mapping.get(virus_strain)
                                 if (

--- a/tests/resources/sharepoint/las2020/mapped/mapped_list_item2.json
+++ b/tests/resources/sharepoint/las2020/mapped/mapped_list_item2.json
@@ -17,7 +17,7 @@
           "material_type": "Virus",
           "name": "GT340C",
           "tars_identifiers": null,
-          "titer": "50",
+          "titer": 50,
           "titer_unit": "gc/mL"
         },
         {
@@ -25,7 +25,7 @@
           "material_type": "Virus",
           "name": null,
           "tars_identifiers": null,
-          "titer": "50 gc/mL",
+          "titer": 50,
           "titer_unit": "gc/mL"
         },
         {

--- a/tests/resources/sharepoint/las2020/mapped/mapped_list_item3.json
+++ b/tests/resources/sharepoint/las2020/mapped/mapped_list_item3.json
@@ -17,7 +17,7 @@
           "material_type": "Virus",
           "name": "GT340C",
           "tars_identifiers": null,
-          "titer": "50",
+          "titer": 700000000000,
           "titer_unit": "gc/mL"
         },
         {
@@ -25,7 +25,7 @@
           "material_type": "Virus",
           "name": null,
           "tars_identifiers": null,
-          "titer": "50 gc/mL",
+          "titer": 50,
           "titer_unit": "gc/mL"
         },
         {

--- a/tests/resources/sharepoint/las2020/raw/list_item2.json
+++ b/tests/resources/sharepoint/las2020/raw/list_item2.json
@@ -168,7 +168,7 @@
   "roVolV5d": null,
   "roTite1": "50",
   "roTite1b": "50 gc/mL",
-  "roTite1c": null,
+  "roTite1c": "abc",
   "roTite1d": null,
   "roTite2": null,
   "roTite2b": null,

--- a/tests/resources/sharepoint/las2020/raw/list_item3.json
+++ b/tests/resources/sharepoint/las2020/raw/list_item3.json
@@ -166,7 +166,7 @@
   "roVolV5b": null,
   "roVolV5c": null,
   "roVolV5d": null,
-  "roTite1": "50",
+  "roTite1": "7E11",
   "roTite1b": "50 gc/mL",
   "roTite1c": null,
   "roTite1d": null,

--- a/tests/sharepoint/las2020/test_mapping.py
+++ b/tests/sharepoint/las2020/test_mapping.py
@@ -61,7 +61,6 @@ class TestLASParsers(TestCase):
             raw_data = list_item[0]
             expected_mapped_data = list_item[1]
             raw_file_name = list_item[2]
-            print(f"Processing file: {raw_file_name}")
             logging.debug(f"Processing file: {raw_file_name}")
             las_model = LASList.model_validate(raw_data)
             mapper = MappedLASList(las=las_model)

--- a/tests/sharepoint/las2020/test_mapping.py
+++ b/tests/sharepoint/las2020/test_mapping.py
@@ -60,7 +60,8 @@ class TestLASParsers(TestCase):
         for list_item in self.list_items:
             raw_data = list_item[0]
             expected_mapped_data = list_item[1]
-            raw_file_name = list_item[1]
+            raw_file_name = list_item[2]
+            print(f"Processing file: {raw_file_name}")
             logging.debug(f"Processing file: {raw_file_name}")
             las_model = LASList.model_validate(raw_data)
             mapper = MappedLASList(las=las_model)

--- a/tests/tars/test_mapping.py
+++ b/tests/tars/test_mapping.py
@@ -33,7 +33,10 @@ class TestTarsResponseHandler(unittest.TestCase):
     inj2 = NanojectInjection.model_construct(
         injection_materials=[ViralMaterial.model_construct(name=" 67890\t")]
     )
-    surgery = Surgery.model_construct(procedures=[inj1, inj2])
+    inj3 = NanojectInjection.model_construct(
+        injection_materials=[ViralMaterial.model_construct(titer=7)]
+    )
+    surgery = Surgery.model_construct(procedures=[inj1, inj2, inj3])
     procedures_response = ModelResponse(
         aind_models=[
             Procedures(subject_id="12345", subject_procedures=[surgery])
@@ -60,7 +63,6 @@ class TestTarsResponseHandler(unittest.TestCase):
         ],
         status_code=StatusCodes.DB_RESPONDED,
     )
-
     def test_map_prep_type_and_protocol(self):
         """Tests that prep_type and protocol are mapped as expected."""
         (

--- a/tests/tars/test_mapping.py
+++ b/tests/tars/test_mapping.py
@@ -63,6 +63,7 @@ class TestTarsResponseHandler(unittest.TestCase):
         ],
         status_code=StatusCodes.DB_RESPONDED,
     )
+
     def test_map_prep_type_and_protocol(self):
         """Tests that prep_type and protocol are mapped as expected."""
         (

--- a/tests/tars/test_mapping.py
+++ b/tests/tars/test_mapping.py
@@ -33,10 +33,7 @@ class TestTarsResponseHandler(unittest.TestCase):
     inj2 = NanojectInjection.model_construct(
         injection_materials=[ViralMaterial.model_construct(name=" 67890\t")]
     )
-    inj3 = NanojectInjection.model_construct(
-        injection_materials=[ViralMaterial.model_construct(titer=7)]
-    )
-    surgery = Surgery.model_construct(procedures=[inj1, inj2, inj3])
+    surgery = Surgery.model_construct(procedures=[inj1, inj2])
     procedures_response = ModelResponse(
         aind_models=[
             Procedures(subject_id="12345", subject_procedures=[surgery])


### PR DESCRIPTION
closes #305 

The Internal server error was coming from the tars endpoint trying to retrieve material.name for a Nonetype. While fixing this, I realized that we were returning validation errors because we were returning a str rather than the expected int type for titer

This PR: 
- ensures the material is not a Nonetype before trying to get list of virus strains
- adds parsing for titer str in the mapping of LAS response (previously was returning an invalid return type). Checks scientific notation or str with unit (parses out unit in this case, otherwise default value).
-  If titer from LAS is a Decimal, it will map to none since that probably means user incorrectly input Concentration info. 
- updates examples for coverage purposes