### PR TITLE
feat: adds bool to allow for partial rig matches

### DIFF
--- a/src/aind_metadata_service/server.py
+++ b/src/aind_metadata_service/server.py
@@ -115,16 +115,20 @@ async def retrieve_bergamo_session(job_settings: BergamoJobSettings):
 
 
 @app.get("/instrument/{instrument_id}")
-async def retrieve_instrument(instrument_id):
+async def retrieve_instrument(instrument_id, partial_match=False):
     """Retrieves instrument from slims"""
-    model_response = slims_client.get_instrument_model_response(instrument_id)
+    model_response = slims_client.get_instrument_model_response(
+        instrument_id, partial_match=partial_match
+    )
     return model_response.map_to_json_response(validate=False)
 
 
 @app.get("/rig/{rig_id}")
-async def retrieve_rig(rig_id):
+async def retrieve_rig(rig_id, partial_match=False):
     """Retrieves rig from slims"""
-    model_response = slims_client.get_rig_model_response(rig_id)
+    model_response = slims_client.get_rig_model_response(
+        rig_id, partial_match=partial_match
+    )
     return model_response.map_to_json_response(validate=False)
 
 

--- a/src/aind_metadata_service/slims/client.py
+++ b/src/aind_metadata_service/slims/client.py
@@ -15,6 +15,7 @@ from aind_slims_api.operations import (
 from pydantic import Extra, Field, SecretStr
 from pydantic_settings import BaseSettings
 from requests.models import Response
+from slims import criteria
 from slims.criteria import equals
 
 from aind_metadata_service.client import StatusCodes
@@ -55,16 +56,29 @@ class SlimsHandler:
         """Checks whether file is a json."""
         return file.headers.get("Content-Type", "") == "application/json"
 
-    def get_instrument_model_response(self, input_id) -> ModelResponse:
+    def get_instrument_model_response(
+        self, input_id: str, partial_match: bool = False
+    ) -> ModelResponse:
         """
         Fetches a response from SLIMS, extracts Instrument models from the
         response and creates a ModelResponse with said models.
         """
         try:
-            inst = self.client.fetch_model(SlimsInstrumentRdrc, name=input_id)
-            attachment = self.client.fetch_attachment(
-                inst, equals("name", input_id)
-            )
+            if partial_match:
+                inst = self.client.fetch_model(
+                    SlimsInstrumentRdrc,
+                    criteria.contains("name", input_id),
+                )
+                attachment = self.client.fetch_attachment(
+                    inst,
+                )
+            else:
+                inst = self.client.fetch_model(
+                    SlimsInstrumentRdrc, name=input_id
+                )
+                attachment = self.client.fetch_attachment(
+                    inst, equals("name", input_id)
+                )
             if attachment:
                 attachment_response = self.client.fetch_attachment_content(
                     attachment
@@ -91,16 +105,29 @@ class SlimsHandler:
             logging.error(repr(e))
             return ModelResponse.internal_server_error_response()
 
-    def get_rig_model_response(self, input_id) -> ModelResponse:
+    def get_rig_model_response(
+        self, input_id: str, partial_match: bool = False
+    ) -> ModelResponse:
         """
         Fetches a response from SLIMS, extracts Rig models from the
         response and creates a ModelResponse with said models.
         """
         try:
-            inst = self.client.fetch_model(SlimsInstrumentRdrc, name=input_id)
-            attachment = self.client.fetch_attachment(
-                inst, equals("name", input_id)
-            )
+            if partial_match:
+                inst = self.client.fetch_model(
+                    SlimsInstrumentRdrc,
+                    criteria.contains("name", input_id),
+                )
+                attachment = self.client.fetch_attachment(
+                    inst,
+                )
+            else:
+                inst = self.client.fetch_model(
+                    SlimsInstrumentRdrc, name=input_id
+                )
+                attachment = self.client.fetch_attachment(
+                    inst, equals("name", input_id)
+                )
             if attachment:
                 attachment_response = self.client.fetch_attachment_content(
                     attachment


### PR DESCRIPTION
Closes #304 

- Adds option to fetch a rig or instrument by partially matching user input (default is find an exact match)
```
{host}/rig/{rig_id}?partial_match=True
```
- Doesn't do any additional validation check. We may need to update version of aind slims api or snippet to avoid pulling stuff like `323_EPHYS1_OPTO_2024-06-18_tube`