### PR TITLE
Feat 309: Updates TARS Mappings

### DIFF
--- a/src/aind_metadata_service/models.py
+++ b/src/aind_metadata_service/models.py
@@ -1,8 +1,8 @@
 """Additional response models not defined in aind-data-schema"""
 
-from typing import Optional
-
+from typing import Optional, List
 from aind_data_schema.core.data_description import Funding
+from aind_data_schema.core.procedures import ViralMaterial
 from pydantic import BaseModel, Field, field_validator
 
 
@@ -33,3 +33,8 @@ class FundingInformation(Funding):
     information from the Funding SmartSheet"""
 
     investigators: Optional[str] = Field(default=None)
+
+class ViralMaterialInformation(ViralMaterial):
+    """Viral Material with Stock Titer from SLIMS"""
+
+    stock_titer: Optional[List[int]] = Field(default=None)

--- a/src/aind_metadata_service/models.py
+++ b/src/aind_metadata_service/models.py
@@ -1,6 +1,6 @@
 """Additional response models not defined in aind-data-schema"""
 
-from typing import List, Optional
+from typing import Optional
 
 from aind_data_schema.core.data_description import Funding
 from aind_data_schema.core.procedures import ViralMaterial
@@ -39,4 +39,4 @@ class FundingInformation(Funding):
 class ViralMaterialInformation(ViralMaterial):
     """Viral Material with Stock Titer from SLIMS"""
 
-    stock_titer: Optional[List[int]] = Field(default=None)
+    stock_titer: Optional[int] = Field(default=None)

--- a/src/aind_metadata_service/models.py
+++ b/src/aind_metadata_service/models.py
@@ -1,6 +1,7 @@
 """Additional response models not defined in aind-data-schema"""
 
-from typing import Optional, List
+from typing import List, Optional
+
 from aind_data_schema.core.data_description import Funding
 from aind_data_schema.core.procedures import ViralMaterial
 from pydantic import BaseModel, Field, field_validator
@@ -33,6 +34,7 @@ class FundingInformation(Funding):
     information from the Funding SmartSheet"""
 
     investigators: Optional[str] = Field(default=None)
+
 
 class ViralMaterialInformation(ViralMaterial):
     """Viral Material with Stock Titer from SLIMS"""

--- a/src/aind_metadata_service/tars/client.py
+++ b/src/aind_metadata_service/tars/client.py
@@ -104,24 +104,6 @@ class TarsClient:
         if not filtered_data:
             raise ValueError(f"No data found for {prep_lot_number}")
         return filtered_data
-    
-    @staticmethod
-    def _filter_virus_response(
-        virus_tars_id: str, response: requests.models.Response
-    ) -> Optional[List]:
-        """
-        Filters response from TARS for exact match.
-        Parameters
-        ----------
-        prep_lot_number: str
-           Prep lot number used to query Virus endpoint.
-        response : requests.models.Response
-           Raw Response from Virus endpoint
-        """
-        data = response.json()["data"]
-        if not data: 
-            raise ValueError(f"No data found for {virus_tars_id}")
-        return data[0]
 
     def _get_molecules_response(
         self, plasmid_name: str
@@ -178,18 +160,13 @@ class TarsClient:
             injection_materials = []
 
             for lot in data:
-                print("Lot", lot)
                 # virus tars id is the preferred virus alias
                 virus_tars_id = next(
                     (alias["name"] for alias in lot["viralPrep"]["virus"]["aliases"] if alias["isPreferred"]), 
                     None
                 )
-                print("virus tars id", virus_tars_id)
-                # check virus registry with tars id 
+                # check virus registry with tars id
                 virus_response = self._get_virus_response(virus_tars_id)
-                # virus_data = self._filter_virus_response(virus_tars_id, virus_response)
-                
-                # check if virus can be assumed as 1 or if we need to loop 
                 injection_material = trh.map_lot_to_injection_material(
                     viral_prep_lot=lot, virus=virus_response.json()["data"][0], virus_tars_id=virus_tars_id
                 )

--- a/src/aind_metadata_service/tars/client.py
+++ b/src/aind_metadata_service/tars/client.py
@@ -124,10 +124,8 @@ class TarsClient:
         )
         response = requests.get(query, headers=headers)
         return response
-    
-    def _get_virus_response(
-        self, virus_name: str
-    ) -> requests.models.Response:
+
+    def _get_virus_response(self, virus_name: str) -> requests.models.Response:
         """
         Retrieves virus from TARS.
         Parameters
@@ -162,13 +160,19 @@ class TarsClient:
             for lot in data:
                 # virus tars id is the preferred virus alias
                 virus_tars_id = next(
-                    (alias["name"] for alias in lot["viralPrep"]["virus"]["aliases"] if alias["isPreferred"]), 
-                    None
+                    (
+                        alias["name"]
+                        for alias in lot["viralPrep"]["virus"]["aliases"]
+                        if alias["isPreferred"]
+                    ),
+                    None,
                 )
                 # check virus registry with tars id
                 virus_response = self._get_virus_response(virus_tars_id)
                 injection_material = trh.map_lot_to_injection_material(
-                    viral_prep_lot=lot, virus=virus_response.json()["data"][0], virus_tars_id=virus_tars_id
+                    viral_prep_lot=lot,
+                    virus=virus_response.json()["data"][0],
+                    virus_tars_id=virus_tars_id,
                 )
                 injection_materials.append(injection_material)
             return ModelResponse(

--- a/src/aind_metadata_service/tars/mapping.py
+++ b/src/aind_metadata_service/tars/mapping.py
@@ -19,7 +19,7 @@ from pydantic import ValidationError
 
 from aind_metadata_service.client import StatusCodes
 from aind_metadata_service.response_handler import ModelResponse
-
+from aind_metadata_service.models import ViralMaterialInformation
 
 class ViralPrepTypes(Enum):
     """Enum of Viral Prep Type options in TARS"""
@@ -51,24 +51,6 @@ class PrepProtocols(Enum):
     MGT1 = "MGT#1.0"
     PHP_SOP_UW = "PHPeB-SOP-UW"
     HGT1 = "HGT#1.0"
-
-
-class VirusAliasPatterns(Enum):
-    """Virus Alias Patterns"""
-
-    # TODO: add pattern for genome_name once confirmed
-    AIP = re.compile(r"^AiP[a-zA-Z0-9_-]+$")
-    AIV = re.compile(r"^AiV[a-zA-Z0-9_-]+$")
-
-
-@dataclass
-class ViralPrepAliases:
-    """Model for mapping viral prep aliases"""
-
-    plasmid_name: Optional[str]
-    material_id: Optional[str]
-    full_genome_name: Optional[str]
-
 
 class TarsResponseHandler:
     """This class will contain methods to handle the response from TARS"""
@@ -125,41 +107,37 @@ class TarsResponseHandler:
             )
             return None
         return datetime.strptime(date, "%Y-%m-%dT%H:%M:%SZ").date()
-
+    
     @staticmethod
-    def map_virus_aliases(aliases: list) -> ViralPrepAliases:
-        """Maps aliases to full_genome_name, material_id, viral prep id"""
-        plasmid_name, material_id, full_genome_name = None, None, None
-        for alias in aliases:
-            name = alias["name"]
-            if VirusAliasPatterns.AIP.value.match(name):
-                plasmid_name = name
-            elif VirusAliasPatterns.AIV.value.match(name):
-                material_id = name
-            else:
-                full_genome_name = name
-        viral_prep_aliases = ViralPrepAliases(
-            plasmid_name=plasmid_name,
-            material_id=material_id,
-            full_genome_name=full_genome_name,
+    def map_plasmid_name(aliases: List[Dict]) -> Optional[str]:
+        """Maps plasmid name from aliases"""
+        return next(
+            (alias["name"] for alias in aliases if alias["isPreferred"]), 
+            None
         )
-        return viral_prep_aliases
-
+    
     @staticmethod
-    def map_full_genome_name(response, plasmid_name) -> Optional[str]:
-        """Maps genome name from molecular response"""
-        full_genome_name = None
-        data = response.json()["data"][0]
-        aliases = data["aliases"]
-        if len(aliases) == 2:
-            if aliases[0]["name"] != plasmid_name:
-                full_genome_name = aliases[0]["name"]
-            elif aliases[1]["name"] != plasmid_name:
-                full_genome_name = aliases[1]["name"]
-        return full_genome_name
+    def map_stock_titer(titers: List[dict]) -> Optional[int]:
+        """Maps titer from viral prep lot"""
+        return [int(titer["result"]) for titer in titers]
+        
+    def map_name_and_plasmid_from_virus_response(self, virus: dict) -> tuple[Optional[str], Optional[str]]:
+        """Maps name and plasmid name from virus response"""
+        names = []
+        plasmid_aliases = []
+        for molecule in virus["molecules"]:
+            if molecule["fullName"]:
+                names.append(molecule["fullName"])
+            plasmid_name = self.map_plasmid_name(molecule["aliases"])
+            if plasmid_name:
+                plasmid_aliases.append(plasmid_name)
+        name = "; ".join(names) if names else None
+        plasmid_alias = "; ".join(plasmid_aliases) if plasmid_aliases else None
+        return name, plasmid_alias
+
 
     def map_lot_to_injection_material(
-        self, viral_prep_lot: dict, viral_prep_aliases: ViralPrepAliases
+        self, viral_prep_lot: dict, virus: dict, virus_tars_id: str
     ) -> ViralMaterial:
         """
         Map prep lot dictionary to injection materials
@@ -167,40 +145,43 @@ class TarsResponseHandler:
         ----------
         viral_prep_lot: dict
             Dictionary of raw viral prep lot data from TARS response.
-        viral_prep_aliases: ViralPrepAliases
-            Prep aliases mapped from TARS viral prep and molecular endpoints.
+        virus: dict
+            Dictionary of raw virus data from TARS response.
         """
         prep_lot_number = viral_prep_lot["lot"]
         prep_date = self._convert_datetime(viral_prep_lot["datePrepped"])
         prep_type, prep_protocol = self._map_prep_type_and_protocol(
             viral_prep_lot["viralPrep"]["viralPrepType"]["name"]
         )
+        name, plasmid_alias = self.map_name_and_plasmid_from_virus_response(virus)
         try:
             tars_virus_identifiers = TarsVirusIdentifiers(
-                virus_tars_id=viral_prep_aliases.material_id,
-                plasmid_tars_alias=viral_prep_aliases.plasmid_name,
+                virus_tars_id=virus_tars_id,
+                plasmid_tars_alias=plasmid_alias,
                 prep_lot_number=prep_lot_number,
                 prep_date=prep_date,
                 prep_type=prep_type,
                 prep_protocol=prep_protocol,
             )
-            return ViralMaterial(
-                name=viral_prep_aliases.full_genome_name,
-                tars_identifiers=tars_virus_identifiers,
+            return ViralMaterialInformation(
+            name=name,
+            tars_identifiers=tars_virus_identifiers,
+            stock_titer=self.map_stock_titer(viral_prep_lot["titers"]),
             )
         except ValidationError:
             tars_virus_identifiers = TarsVirusIdentifiers.model_construct(
-                virus_tars_id=viral_prep_aliases.material_id,
-                plasmid_tars_alias=viral_prep_aliases.plasmid_name,
+                virus_tars_id=virus_tars_id,
+                plasmid_tars_alias=plasmid_alias,
                 prep_lot_number=prep_lot_number,
                 prep_date=prep_date,
                 prep_type=prep_type,
                 prep_protocol=prep_protocol,
             )
-            return ViralMaterial.model_construct(
-                name=viral_prep_aliases.full_genome_name,
+            return ViralMaterialInformation.model_construct(
+                name=name,
                 tars_identifiers=tars_virus_identifiers,
-            )
+                stock_titer=self.map_stock_titer(viral_prep_lot["titers"]),
+                )
 
     @staticmethod
     def get_virus_strains(response: ModelResponse) -> List:

--- a/src/aind_metadata_service/tars/mapping.py
+++ b/src/aind_metadata_service/tars/mapping.py
@@ -124,11 +124,9 @@ class TarsResponseHandler:
     @staticmethod
     def map_stock_titer(titers: List[dict]) -> Optional[int]:
         """Maps titer from viral prep lot"""
-        return [
-            int(titer["result"])
-            for titer in titers
-            if titer.get("result") is not None
-        ]
+        if titers and titers[0].get("result") is not None:
+            return int(titers[0]["result"])
+        return None
 
     def map_name_and_plasmid_from_virus_response(
         self, virus: dict
@@ -183,7 +181,7 @@ class TarsResponseHandler:
                 name=name,
                 tars_identifiers=tars_virus_identifiers,
                 stock_titer=self.map_stock_titer(
-                    viral_prep_lot.get("titers", [])
+                    viral_prep_lot.get("titers", None)
                 ),
             )
         except ValidationError:
@@ -199,7 +197,7 @@ class TarsResponseHandler:
                 name=name,
                 tars_identifiers=tars_virus_identifiers,
                 stock_titer=self.map_stock_titer(
-                    viral_prep_lot.get("titers", [])
+                    viral_prep_lot.get("titers", None)
                 ),
             )
 

--- a/tests/tars/test_client.py
+++ b/tests/tars/test_client.py
@@ -76,7 +76,7 @@ class TestTarsClient(unittest.TestCase):
             material_type="Virus",
             name="rAAV-MGT_789",
             tars_identifiers=tars_virus_identifiers,
-            stock_titer=[413000000000],
+            stock_titer=413000000000,
         )
 
         mock_credential.return_value.get_token.return_value = (

--- a/tests/tars/test_client.py
+++ b/tests/tars/test_client.py
@@ -65,8 +65,8 @@ class TestTarsClient(unittest.TestCase):
             resource="https://some_resource",
         )
         tars_virus_identifiers = TarsVirusIdentifiers(
-            virus_tars_id="AiP123",
-            plasmid_tars_alias="ExP123",
+            virus_tars_id="AiV123",
+            plasmid_tars_alias="AiP456",
             prep_lot_number="12345",
             prep_date=date(2023, 12, 15),
             prep_type="Crude",
@@ -242,11 +242,11 @@ class TestTarsClient(unittest.TestCase):
                         "virus": {
                             "aliases": [
                                 {
-                                    "name": "AiP123",
+                                    "name": "AiV123",
                                     "isPreferred": True,
                                 },
                                 {
-                                    "name": "AiV456",
+                                    "name": "AiP456",
                                     "isPreferred": False,
                                 },
                             ]
@@ -266,7 +266,7 @@ class TestTarsClient(unittest.TestCase):
                 {
                     "aliases": [
                         {
-                            "name": "AiP123",
+                            "name": "AiV123",
                             "isPreferred": True,
                         },
                         {
@@ -278,7 +278,7 @@ class TestTarsClient(unittest.TestCase):
                         {
                             "aliases": [
                                 {
-                                    "name": "ExP123",
+                                    "name": "AiP456",
                                     "isPreferred": True,
                                 },
                                 {

--- a/tests/tars/test_mapping.py
+++ b/tests/tars/test_mapping.py
@@ -194,7 +194,7 @@ class TestTarsResponseHandler(unittest.TestCase):
         virus_response = {
             "aliases": [
                 {
-                    "name": "AiP123",
+                    "name": "AiV123",
                     "isPreferred": True,
                 },
                 {
@@ -206,7 +206,7 @@ class TestTarsResponseHandler(unittest.TestCase):
                 {
                     "aliases": [
                         {
-                            "name": "ExP123",
+                            "name": "AiP456",
                             "isPreferred": True,
                         },
                         {
@@ -221,11 +221,11 @@ class TestTarsResponseHandler(unittest.TestCase):
         injection_material = self.handler.map_lot_to_injection_material(
             viral_prep_lot=prep_lot_response,
             virus=virus_response,
-            virus_tars_id="AiP123",
+            virus_tars_id="AiV123",
         )
         tars_virus_identifiers = TarsVirusIdentifiers(
-            virus_tars_id="AiP123",
-            plasmid_tars_alias="ExP123",
+            virus_tars_id="AiV123",
+            plasmid_tars_alias="AiP456",
             prep_lot_number="12345",
             prep_date=date(2023, 12, 15),
             prep_type="Crude",

--- a/tests/tars/test_mapping.py
+++ b/tests/tars/test_mapping.py
@@ -235,7 +235,7 @@ class TestTarsResponseHandler(unittest.TestCase):
             material_type="Virus",
             name="rAAV-MGT_789",
             tars_identifiers=tars_virus_identifiers,
-            stock_titer=[413000000000],
+            stock_titer=413000000000,
         )
         self.assertIsInstance(injection_material, ViralMaterial)
         self.assertEqual(injection_material, expected_injection_material)
@@ -272,9 +272,8 @@ class TestTarsResponseHandler(unittest.TestCase):
 
         self.assertIsInstance(injection_material, ViralMaterialInformation)
         self.assertIsNone(injection_material.tars_identifiers.prep_date)
-        self.assertEqual(
-            injection_material.stock_titer, []
-        )  # Should be an empty list due to invalid titer
+        self.assertIsNone(injection_material.stock_titer)
+
         self.assertIsNone(injection_material.name)
 
     def test_get_virus_strains(self):


### PR DESCRIPTION
closes #309 

- Creates model ViralMaterialInformation to allow extra field "stock_titer" to hold Titer data from TARS
- Also updates mappings for Virus identifiers using TARS Virus endpoint
- Stock titer is only available in the TARS endpoint result, the procedures response integrates a ViralMaterial object with titer from NSB 