### PR TITLE
adds support for nsb 2023-2024 archive list

### DIFF
--- a/src/aind_metadata_service/server.py
+++ b/src/aind_metadata_service/server.py
@@ -348,7 +348,7 @@ async def retrieve_procedures(subject_id):
     sp2025_response = await run_in_threadpool(
         sharepoint_client.get_procedure_info,
         subject_id=subject_id,
-        list_id=sharepoint_settings.nsb_2025_list_id,
+        list_id=sharepoint_settings.nsb_present_list_id,
     )
     las2020_response = await run_in_threadpool(
         sharepoint_client.get_procedure_info,

--- a/src/aind_metadata_service/server.py
+++ b/src/aind_metadata_service/server.py
@@ -345,6 +345,11 @@ async def retrieve_procedures(subject_id):
         subject_id=subject_id,
         list_id=sharepoint_settings.nsb_2023_list_id,
     )
+    sp2025_response = await run_in_threadpool(
+        sharepoint_client.get_procedure_info,
+        subject_id=subject_id,
+        list_id=sharepoint_settings.nsb_2025_list_id,
+    )
     las2020_response = await run_in_threadpool(
         sharepoint_client.get_procedure_info,
         subject_id=subject_id,
@@ -356,6 +361,7 @@ async def retrieve_procedures(subject_id):
             lb_response,
             sp2019_response,
             sp2023_response,
+            sp2025_response,
             las2020_response,
         ]
     )


### PR DESCRIPTION
closes #372 

The NSB 2023 List got split into 2 lists when it was migrated: (1) SWR 2023-Present and (2) SWR 2023-2024 Archive. This PR:
- Adds support for archive list
- Fetches procedures and intended measurements from archive 
- Filters out duplicates (both lists currently contain Surgical requests from 2024)