### PR TITLE
Fix: Adds updated procedure names

### DIFF
--- a/src/aind_metadata_service/sharepoint/client.py
+++ b/src/aind_metadata_service/sharepoint/client.py
@@ -477,7 +477,7 @@ class SharePointClient:
                 unique.append(item)
             else:
                 logging.info("Duplicate item found and removed.")
-            
+
         return unique
 
     def _handle_response_from_sharepoint(

--- a/src/aind_metadata_service/sharepoint/client.py
+++ b/src/aind_metadata_service/sharepoint/client.py
@@ -475,7 +475,9 @@ class SharePointClient:
             if identifier not in seen:
                 seen.add(identifier)
                 unique.append(item)
-
+            else:
+                logging.info("Duplicate item found and removed.")
+            
         return unique
 
     def _handle_response_from_sharepoint(

--- a/src/aind_metadata_service/sharepoint/nsb2023/mapping.py
+++ b/src/aind_metadata_service/sharepoint/nsb2023/mapping.py
@@ -5394,7 +5394,7 @@ class MappedNSBList:
             NSBProcedure.SX_26_ISI_GUIDED__INJECTI,
             NSBProcedure.SX_12__STEREOTAXIC__INJEC,
             NSBProcedure.SX_21__FIBER__OPTIC__IMPL,
-            NSBProcedure.INJECTION_FIBER_OPTIC_IMP_
+            NSBProcedure.INJECTION_FIBER_OPTIC_IMP_,
         }
 
     def has_cran_procedure(self) -> bool:
@@ -5420,6 +5420,11 @@ class MappedNSBList:
             NSBProcedure.SX_14__VISUAL__CTX_NP,
             NSBProcedure.SX_15_WHC_NP,
             NSBProcedure.SX_16_INJ_WHC_NP,
+            NSBProcedure.GRID_INJ_6_OR_9_VISUAL,
+            NSBProcedure.MOTOR_CTX_2_P,
+            NSBProcedure.INJ_MOTOR_CTX_2_P,
+            NSBProcedure.GRID_INJ_6_OR_9_MOTOR_C,
+            NSBProcedure.INJ_WHC_NP,
         }
 
     def surgery_during_info(

--- a/src/aind_metadata_service/sharepoint/nsb2023/mapping.py
+++ b/src/aind_metadata_service/sharepoint/nsb2023/mapping.py
@@ -5394,6 +5394,7 @@ class MappedNSBList:
             NSBProcedure.SX_26_ISI_GUIDED__INJECTI,
             NSBProcedure.SX_12__STEREOTAXIC__INJEC,
             NSBProcedure.SX_21__FIBER__OPTIC__IMPL,
+            NSBProcedure.INJECTION_FIBER_OPTIC_IMP_
         }
 
     def has_cran_procedure(self) -> bool:

--- a/src/aind_metadata_service/sharepoint/nsb2023/models.py
+++ b/src/aind_metadata_service/sharepoint/nsb2023/models.py
@@ -770,6 +770,7 @@ class Procedure(Enum, metaclass=EnumMeta):
     HP_ONLY = "HP Only"
     HP_TRANSCRANIAL = "HP Transcranial"
     INJECTION_FIBER_OPTIC_IMP = "Injection+Fiber Optic Implant (with Headpost)"
+    INJECTION_FIBER_OPTIC_IMP_ = "Injection + Fiber Optic Implant (with Headpost)"
     INJ_MOTOR_CTX = "INJ + Motor Ctx"
     INJ_VISUAL_CTX_2_P = "INJ + Visual Ctx 2P"
     INJ_WHC_NP_1_INJECTION_LO = "INJ + WHC NP (1 Injection Location)"

--- a/src/aind_metadata_service/sharepoint/nsb2023/models.py
+++ b/src/aind_metadata_service/sharepoint/nsb2023/models.py
@@ -762,7 +762,6 @@ class Procedure(Enum, metaclass=EnumMeta):
     SX__OVIDUCT__INJECTION = "Sx- Oviduct Injection"
 
     # Added missing attributes
-    """Enum class for Procedure"""
     CUSTOM = "Custom"
     DHC = "DHC"
     FIBER_OPTIC_IMPLANT_WITH = "Fiber Optic Implant (with Headpost)"
@@ -770,7 +769,6 @@ class Procedure(Enum, metaclass=EnumMeta):
     HP_ONLY = "HP Only"
     HP_TRANSCRANIAL = "HP Transcranial"
     INJECTION_FIBER_OPTIC_IMP = "Injection+Fiber Optic Implant (with Headpost)"
-    INJECTION_FIBER_OPTIC_IMP_ = "Injection + Fiber Optic Implant (with Headpost)"
     INJ_MOTOR_CTX = "INJ + Motor Ctx"
     INJ_VISUAL_CTX_2_P = "INJ + Visual Ctx 2P"
     INJ_WHC_NP_1_INJECTION_LO = "INJ + WHC NP (1 Injection Location)"
@@ -782,6 +780,22 @@ class Procedure(Enum, metaclass=EnumMeta):
     VISUAL_CTX_NP = "Visual Ctx NP"
     WHC_2_P = "WHC 2P"
     WHC_NP = "WHC NP"
+
+    # Missing attributes after Sx Procedure # Removal
+    MOTOR_CTX_2_P = "Motor Ctx 2P"
+    GRID_INJ_6_OR_9_VISUAL = "Grid INJ (6 or 9) + Visual Ctx 2P"
+    INJ_MOTOR_CTX_2_P = "INJ + Motor Ctx 2P"
+    GRID_INJ_6_OR_9_MOTOR_C = "Grid INJ (6 or 9) + Motor Ctx 2P"
+    INJ_WHC_NP = "INJ + WHC NP"
+    INJ_DHC = "INJ+DHC"
+    INJECTION_FIBER_OPTIC_IMP_ = (
+        "Injection + Fiber Optic Implant (with Headpost)"
+    )
+    STEREOTAXIC_INJECTIONS_1 = "Stereotaxic injections: 1 INJ material"
+    STEREOTAXIC_INJECTIONS_2 = "Stereotaxic injections: 2+ INJ materials"
+    EMG__ARRAY = "EMG Array"
+    TESTES__INJECTION = "Testes Injection"
+    OVIDUCT__INJECTION = "Oviduct Injection"
 
 
 class Headpost(Enum, metaclass=EnumMeta):


### PR DESCRIPTION
closes #384 

The NSB Present list had numbers ("Sx-#") in the procedure options. This was apparently a bug, and was removed which caused missing mappings for craniotomies and headframes on our end. This PR adds the new procedure names (without the #s). Left the Sx options in the enum for backwards compatibility.