### PR TITLE
feat: integrate perfusions in procedures response

### DIFF
--- a/src/aind_metadata_service/server.py
+++ b/src/aind_metadata_service/server.py
@@ -364,10 +364,10 @@ async def retrieve_procedures(subject_id):
     Retrieves procedure info from SharePoint and Labtracks servers
     """
     sharepoint_client = SharePointClient.from_settings(sharepoint_settings)
-    # lb_client = LabTracksClient.from_settings(labtracks_settings)
-    # lb_response = await run_in_threadpool(
-    #     lb_client.get_procedures_info, subject_id=subject_id
-    # )
+    lb_client = LabTracksClient.from_settings(labtracks_settings)
+    lb_response = await run_in_threadpool(
+        lb_client.get_procedures_info, subject_id=subject_id
+    )
     sp2019_response = await run_in_threadpool(
         sharepoint_client.get_procedure_info,
         subject_id=subject_id,
@@ -403,7 +403,7 @@ async def retrieve_procedures(subject_id):
     # merge subject procedures
     merged_response = sharepoint_client.merge_responses(
         [
-            # lb_response,
+            lb_response,
             sp2019_response,
             sp2023_response,
             sp2025_response,

--- a/src/aind_metadata_service/slims/ecephys/handler.py
+++ b/src/aind_metadata_service/slims/ecephys/handler.py
@@ -3,8 +3,9 @@ Module to handle fetching ephys data from slims and parsing it to a model
 """
 
 from datetime import datetime
-from typing import List, Optional, Tuple
 from decimal import Decimal
+from typing import List, Optional, Tuple
+
 from networkx import DiGraph, descendants
 from pydantic import BaseModel
 from slims.criteria import equals

--- a/src/aind_metadata_service/slims/water_restriction/handler.py
+++ b/src/aind_metadata_service/slims/water_restriction/handler.py
@@ -4,11 +4,12 @@ and parsing it to a model.
 """
 
 from datetime import datetime
-from typing import List, Optional, Tuple
 from decimal import Decimal
+from typing import List, Optional, Tuple
+
 from networkx import DiGraph, descendants
 from pydantic import BaseModel
-from slims.criteria import equals, conjunction
+from slims.criteria import conjunction, equals
 
 from aind_metadata_service.slims.table_handler import (
     SlimsTableHandler,

--- a/src/aind_metadata_service/slims/water_restriction/mapping.py
+++ b/src/aind_metadata_service/slims/water_restriction/mapping.py
@@ -1,17 +1,17 @@
 """Module for mapping water restriction data from slims"""
 
+import logging
 from datetime import datetime
-from typing import List, Optional, Union
 from decimal import Decimal
-from aind_data_schema.core.procedures import (
-    WaterRestriction,
-)
+from typing import List, Optional, Union
+
+from aind_data_schema.core.procedures import WaterRestriction
 from aind_data_schema_models.units import MassUnit
 from pydantic import BaseModel
+
 from aind_metadata_service.slims.water_restriction.handler import (
     SlimsWaterRestrictionData,
 )
-import logging
 
 
 class WaterRestrictionData(BaseModel):

--- a/tests/slims/ecephys/test_handler.py
+++ b/tests/slims/ecephys/test_handler.py
@@ -3,10 +3,11 @@
 import json
 import os
 import unittest
+from decimal import Decimal
 from pathlib import Path
 from typing import Any, Dict
 from unittest.mock import MagicMock, patch
-from decimal import Decimal
+
 from slims.internal import Record
 
 from aind_metadata_service.slims.ecephys.handler import (

--- a/tests/slims/water_restriction/test_handler.py
+++ b/tests/slims/water_restriction/test_handler.py
@@ -3,15 +3,17 @@
 import json
 import os
 import unittest
+from datetime import datetime
+from decimal import Decimal
 from pathlib import Path
 from typing import Any, Dict
 from unittest.mock import MagicMock, patch
-from datetime import datetime
+
 from slims.internal import Record
-from decimal import Decimal
+
 from aind_metadata_service.slims.water_restriction.handler import (
-    SlimsWaterRestrictionHandler,
     SlimsWaterRestrictionData,
+    SlimsWaterRestrictionHandler,
 )
 
 RESOURCES_DIR = (

--- a/tests/slims/water_restriction/test_mapping.py
+++ b/tests/slims/water_restriction/test_mapping.py
@@ -2,10 +2,13 @@
 
 import os
 import unittest
-from unittest.mock import patch
-from datetime import datetime, timezone, date
+from datetime import date, datetime, timezone
 from decimal import Decimal
 from pathlib import Path
+from unittest.mock import patch
+
+from aind_data_schema.core.procedures import WaterRestriction
+from aind_data_schema_models.units import MassUnit, UnitlessUnit, VolumeUnit
 
 from aind_metadata_service.slims.water_restriction.handler import (
     SlimsWaterRestrictionData,
@@ -14,8 +17,6 @@ from aind_metadata_service.slims.water_restriction.mapping import (
     SlimsWaterRestrictionMapper,
     WaterRestrictionData,
 )
-from aind_data_schema.core.procedures import WaterRestriction
-from aind_data_schema_models.units import MassUnit, VolumeUnit, UnitlessUnit
 
 RESOURCES_DIR = (
     Path(os.path.dirname(os.path.realpath(__file__)))


### PR DESCRIPTION
closes #391 

This PR:
- adds method to create procedures model response to perfusion mapper
- integrates perfusions from smartsheet into the procedures response
- adds unit tests

Note:
- only subject_id in the smartsheet is '689418'. you can test http://localhost:5000/procedures/689418 to see the perfusions