### PR TITLE
fix: checks cntn_id for subject_id field

### DIFF
--- a/src/aind_metadata_service/slims/histology/handler.py
+++ b/src/aind_metadata_service/slims/histology/handler.py
@@ -153,7 +153,7 @@ class SlimsHistologyHandler(SlimsTableHandler):
         specimen_id = None
         subject_id = None
         for record in records:
-            n_subject_id = get_attr_or_none(record, "cntn_cf_parentBarcode")
+            n_subject_id = get_attr_or_none(record, "cntn_id")
             if n_subject_id is not None:
                 subject_id = n_subject_id
             n_specimen_id = get_attr_or_none(record, "cntn_barCode")

--- a/src/aind_metadata_service/slims/imaging/handler.py
+++ b/src/aind_metadata_service/slims/imaging/handler.py
@@ -76,9 +76,7 @@ class SlimsImagingHandler(SlimsTableHandler):
                 table_name = g.nodes[n]["table_name"]
                 row = g.nodes[n]["row"]
                 if table_name == "Content":
-                    n_subject_id = get_attr_or_none(
-                        row, "cntn_cf_parentBarcode"
-                    )
+                    n_subject_id = get_attr_or_none(row, "cntn_id")
                     n_specimen_id = get_attr_or_none(row, "cntn_barCode")
                     spim_data.subject_id = n_subject_id
                     spim_data.specimen_id = n_specimen_id
@@ -163,11 +161,7 @@ class SlimsImagingHandler(SlimsTableHandler):
                     spim_data.cell_segmentation_channels = get_attr_or_none(
                         row, "ordr_cf_fluorescenceChannels_CellSegmentation"
                     )
-            if (
-                subject_id is None
-                or subject_id == spim_data.subject_id
-                or subject_id == spim_data.specimen_id
-            ):
+            if subject_id is None or subject_id == spim_data.subject_id:
                 spim_data_list.append(spim_data)
         return spim_data_list
 

--- a/tests/resources/slims/histology/content.json
+++ b/tests/resources/slims/histology/content.json
@@ -25,6 +25,12 @@
          },
          {
             "name": "cntn_cf_parentBarcode",
+            "value": "754372_parent",
+            "datatype": "STRING",
+            "title": "Parent barcode"
+         },
+         {
+            "name": "cntn_id",
             "value": "754372",
             "datatype": "STRING",
             "title": "Parent barcode"

--- a/tests/resources/slims/imaging/content.json
+++ b/tests/resources/slims/imaging/content.json
@@ -35,6 +35,12 @@
          },
          {
             "name": "cntn_cf_parentBarcode",
+            "value": "744742_parent",
+            "datatype": "STRING",
+            "title": "Parent Barcode"
+         },
+         {
+            "name": "cntn_id",
             "value": "744742",
             "datatype": "STRING",
             "title": "Parent Barcode"

--- a/tests/slims/imaging/test_handler.py
+++ b/tests/slims/imaging/test_handler.py
@@ -187,48 +187,6 @@ class TestSlimsImagingHandler(unittest.TestCase):
         self.assertEqual(expected_spim_data, spim_data)
 
     @patch("slims.slims.Slims")
-    def test_parse_graph_specimen_id(self, mock_slims: MagicMock):
-        """Tests _parse_graph method filters specimen_id."""
-        mock_slims.fetch.side_effect = self.fetch_side_effect
-        handler = SlimsImagingHandler(client=mock_slims)
-        g, root_nodes = handler._get_graph()
-        spim_data = handler._parse_graph(
-            g=g, root_nodes=root_nodes, subject_id="740610"
-        )
-        expected_spim_data = [
-            SlimsSpimData(
-                experiment_run_created_on=1739301437964,
-                specimen_id="740610",
-                subject_id="BRN00000017",
-                protocol_name="Imaging cleared mouse brains on SmartSPIM",
-                protocol_id=(
-                    "<a href="
-                    '"https://dx.doi.org/10.17504/protocols.io.3byl4jo1rlo5/'
-                    'v1" '
-                    'target="_blank" '
-                    'rel="nofollow noopener noreferrer">'
-                    "Imaging cleared mouse brains on SmartSPIM"
-                    "</a>"
-                ),
-                date_performed=1739301420000,
-                chamber_immersion_medium="Ethyl Cinnamate",
-                sample_immersion_medium="Ethyl Cinnamate",
-                chamber_refractive_index=Decimal("1.557"),
-                sample_refractive_index=Decimal("1.557"),
-                instrument_id="440_SmartSPIM1_20240327",
-                experimenter_name="Person R",
-                z_direction="Superior to Inferior",
-                y_direction="Anterior to Posterior",
-                x_direction="Left to Right",
-                imaging_channels=None,
-                stitching_channels=None,
-                ccf_registration_channels=None,
-                cell_segmentation_channels=None,
-            )
-        ]
-        self.assertEqual(expected_spim_data, spim_data)
-
-    @patch("slims.slims.Slims")
     def test_get_spim_data_from_slims(self, mock_slims: MagicMock):
         """Tests get_spim_data_from_slims method"""
         mock_slims.fetch.side_effect = self.fetch_side_effect


### PR DESCRIPTION
related to #401 

- reverts #402:
- instead of checking the cntn_barCode ("specimen id") and cntn_parentbarCode, which relies on relationships between content in SLIMS, we can check a field "cntn_id" which always represents the labtracks ID.  
- updates subject_id check in histology and smartspim imaging workflows

Note: 
- Saskia mentioned that specimen_id should look like {subject_id}_XXX . That's not represented in SLIMS so I wonder whether we should change the name to something more SLIMS like "barcode" 