### PR TITLE
fix: validates models

### DIFF
--- a/aind-metadata-service-server/pyproject.toml
+++ b/aind-metadata-service-server/pyproject.toml
@@ -92,7 +92,7 @@ line_length = 79
 profile = "black"
 
 [tool.interrogate]
-exclude = ["setup.py", "docs", "build"]
+exclude = ["setup.py", "docs", "build", "env"]
 fail-under = 100
 
 [tool.pytest.ini_options]

--- a/aind-metadata-service-server/src/aind_metadata_service_server/mappers/responses.py
+++ b/aind-metadata-service-server/src/aind_metadata_service_server/mappers/responses.py
@@ -1,0 +1,29 @@
+"""Validates aind models and maps to a JSONResponse."""
+
+import logging
+
+from fastapi.responses import JSONResponse
+from pydantic import BaseModel, ValidationError
+
+
+def map_to_response(model: BaseModel) -> JSONResponse:
+    """
+    Maps a pydantic model to a JSONResponse message. If the model is valid,
+    then it will return a 200 status code. If the model is not valid, then it
+    will return a 400 status code with the validation errors in the headers
+    under the 'X-Error-Message' key.
+    """
+
+    try:
+        validate = model.model_validate(model.model_dump())
+        content = validate.model_dump(mode="json")
+        return JSONResponse(content=content)
+    except ValidationError as e:
+        content = model.model_dump(mode="json")
+        errors = e.json()
+        logging.warning(errors)
+        return JSONResponse(
+            status_code=400,
+            content=content,
+            headers={"X-Error-Message": errors},
+        )

--- a/aind-metadata-service-server/src/aind_metadata_service_server/routes/subject.py
+++ b/aind-metadata-service-server/src/aind_metadata_service_server/routes/subject.py
@@ -1,8 +1,10 @@
 """Module to handle subject endpoints"""
 
-from aind_data_schema.core.subject import Subject
+import logging
+
 from fastapi import APIRouter, Depends, HTTPException, Path
 
+from aind_metadata_service_server.mappers.responses import map_to_response
 from aind_metadata_service_server.mappers.subject import SubjectMapper
 from aind_metadata_service_server.sessions import (
     get_labtracks_api_instance,
@@ -12,7 +14,7 @@ from aind_metadata_service_server.sessions import (
 router = APIRouter()
 
 
-@router.get("/api/v2/subject/{subject_id}", response_model=Subject)
+@router.get("/api/v2/subject/{subject_id}")
 async def get_subject(
     subject_id: str = Path(
         ...,
@@ -54,6 +56,7 @@ async def get_subject(
     if len(subjects) == 0:
         raise HTTPException(status_code=404, detail="Not found")
     elif len(subjects) > 1:
+        logging.error(f"Too many responses for {subject_id}!")
         raise HTTPException(status_code=500)
     else:
-        return subjects[0]
+        return map_to_response(subjects[0])

--- a/aind-metadata-service-server/tests/test_mappers/test_responses.py
+++ b/aind-metadata-service-server/tests/test_mappers/test_responses.py
@@ -1,0 +1,53 @@
+"""Tests mapping pydantic models to JSONResponses."""
+
+import json
+import unittest
+
+from pydantic import BaseModel
+
+from aind_metadata_service_server.mappers.responses import map_to_response
+
+
+class ExampleModel(BaseModel):
+    """Model for testing purposes."""
+
+    name: str
+    id: int
+    val: str = "default_value"
+
+
+class TestResponses(unittest.TestCase):
+    """Test methods in responses module"""
+
+    def test_map_to_200_response(self):
+        """Tests valid model is mapped to a 200 response."""
+
+        model = ExampleModel(name="abc", id=123)
+        response = map_to_response(model=model)
+        self.assertEqual(200, response.status_code)
+        self.assertEqual(
+            {"name": "abc", "id": 123, "val": "default_value"},
+            json.loads(response.body.decode("utf-8")),
+        )
+
+    def test_map_to_400_response(self):
+        """Tests invalid model is mapped to a 400 response."""
+
+        model = ExampleModel.model_construct(name="abc")
+        with self.assertLogs(level="DEBUG") as captured:
+            response = map_to_response(model=model)
+        self.assertEqual(400, response.status_code)
+        self.assertEqual(
+            {"name": "abc", "val": "default_value"},
+            json.loads(response.body.decode("utf-8")),
+        )
+        expected_error_message = "Field required"
+        response_header_msg = json.loads(response.headers["x-error-message"])[
+            0
+        ]["msg"]
+        self.assertEqual(expected_error_message, response_header_msg)
+        self.assertEqual(1, len(captured.output))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
- Adds `env` to interrogate ignore list
- Adds method to validate models and return JSONResponses
- Logs validation errors as warnings to server logs
- Adds validation errors to response headers
- Removes response_model in subject endpoint to suppress it from openapi schema.