### PR TITLE
feat: adds legacy slims endpoints to api/v2

### DIFF
--- a/aind-metadata-service-server/src/aind_metadata_service_server/main.py
+++ b/aind-metadata-service-server/src/aind_metadata_service_server/main.py
@@ -14,6 +14,8 @@ from aind_metadata_service_server.routes import (
     healthcheck,
     index,
     procedures,
+    rig_and_instrument,
+    slims,
     subject,
     v1_proxy,
 )
@@ -54,6 +56,8 @@ app.include_router(healthcheck.router)
 app.include_router(subject.router)
 app.include_router(procedures.router)
 app.include_router(funding.router)
+app.include_router(slims.router)
+app.include_router(rig_and_instrument.router)
 app.include_router(index.router)
 
 # Clean up the methods names that is generated in the client code

--- a/aind-metadata-service-server/src/aind_metadata_service_server/models.py
+++ b/aind-metadata-service-server/src/aind_metadata_service_server/models.py
@@ -1,10 +1,20 @@
 """Models and schema definitions for backend data structures"""
 
-from typing import List, Literal, Optional
+import html
+import logging
+import xml.etree.ElementTree as ET
+from datetime import datetime
+from typing import Any, List, Literal, Optional
 
 from aind_data_schema.components.identifiers import Person
 from aind_data_schema.components.injection_procedures import ViralMaterial
 from aind_data_schema.core.data_description import Funding
+from aind_slims_service_async_client import (
+    EcephysStreamModule,
+    SlimsEcephysData,
+    SlimsHistologyData,
+    SlimsSpimData,
+)
 from pydantic import BaseModel, Field, field_validator
 
 from aind_metadata_service_server import __version__
@@ -61,3 +71,76 @@ class FundingInformation(Funding):
     information from the Funding SmartSheet"""
 
     investigators: Optional[List[Person]] = Field(default=None)
+
+
+class SpimData(SlimsSpimData):
+    """Class to for Slims Spim Data with proper datetime info."""
+
+    date_performed: Optional[datetime] = Field(default=None)
+
+    @field_validator("protocol_id", mode="before")
+    @classmethod
+    def parse_protocol_id(cls, v: Any) -> Optional[str]:
+        """Parses protocol id from html"""
+        if v is None:
+            return None
+        try:
+            root = ET.fromstring(v)
+            return root.get("href")
+        except ET.ParseError:
+            return v
+        except Exception as e:
+            logging.warning(
+                f"There was an exception parsing the protocol_id field: {e}"
+            )
+            return None
+
+
+class HistologyData(SlimsHistologyData):
+    """Class to for Slims Histology Data with proper protocol id."""
+
+    @field_validator("protocol_id", mode="before")
+    @classmethod
+    def parse_protocol_id(cls, v: Any) -> Optional[str]:
+        """Parses protocol id from html"""
+        if v is None:
+            return None
+        try:
+            root = ET.fromstring(v)
+            return root.get("href")
+        except ET.ParseError:
+            return v
+        except Exception as e:
+            logging.warning(
+                f"There was an exception parsing the protocol_id field: {e}"
+            )
+            return None
+
+
+class EcephysData(SlimsEcephysData):
+    """Class for Slims Ecephys Data with proper stream data"""
+
+    @field_validator("stream_modules", mode="after")
+    @classmethod
+    def parse_micrometer_units(
+        cls, v: Optional[List[EcephysStreamModule]]
+    ) -> Optional[List[EcephysStreamModule]]:
+        """Converts html mu into unicode mu in units."""
+        if v is None:
+            return None
+        for module in v:
+            if module.ccf_coordinate_unit:
+                module.ccf_coordinate_unit = html.unescape(
+                    module.ccf_coordinate_unit
+                )
+            if module.bregma_target_unit:
+                module.bregma_target_unit = html.unescape(
+                    module.bregma_target_unit
+                )
+            if module.surface_z_unit:
+                module.surface_z_unit = html.unescape(module.surface_z_unit)
+            if module.manipulator_unit:
+                module.manipulator_unit = html.unescape(
+                    module.manipulator_unit
+                )
+        return v

--- a/aind-metadata-service-server/src/aind_metadata_service_server/routes/rig_and_instrument.py
+++ b/aind-metadata-service-server/src/aind_metadata_service_server/routes/rig_and_instrument.py
@@ -1,0 +1,74 @@
+"""Module to handle rig and instrument endpoints"""
+
+from aind_slims_service_async_client import DefaultApi
+from fastapi import APIRouter, Depends, HTTPException, Path, Query
+from fastapi.responses import JSONResponse
+
+from aind_metadata_service_server.sessions import get_slims_api_instance
+
+router = APIRouter()
+
+
+@router.get("/api/v2/rig/{rig_id}")
+async def get_rig(
+    rig_id: str = Path(
+        ...,
+        openapi_examples={
+            "default": {
+                "summary": "A sample rig ID",
+                "description": "Example rig ID for SLIMS",
+                "value": "323_EPHYS1_20250205",
+            }
+        },
+    ),
+    partial_match: bool = Query(False, alias="partial_match"),
+    slims_api_instance: DefaultApi = Depends(get_slims_api_instance),
+):
+    """
+    ## Rig
+    Return a Rig.
+    """
+    rigs = await slims_api_instance.get_aind_instrument(
+        input_id=rig_id, partial_match=partial_match
+    )
+    if len(rigs) == 0:
+        raise HTTPException(status_code=404, detail="Not found")
+    else:
+        return JSONResponse(
+            status_code=400,
+            content=rigs,
+            headers={"X-Error-Message": "Models have not been validated."},
+        )
+
+
+@router.get("/api/v2/instrument/{instrument_id}")
+async def get_instrument(
+    instrument_id: str = Path(
+        ...,
+        openapi_examples={
+            "default": {
+                "summary": "A sample instrument ID",
+                "description": "Example instrument ID for SLIMS",
+                "value": "440_SmartSPIM1_20240327",
+            }
+        },
+    ),
+    partial_match: bool = Query(False, alias="partial_match"),
+    slims_api_instance: DefaultApi = Depends(get_slims_api_instance),
+):
+    """
+    ## Instrument
+    Return an Instrument.
+    """
+
+    instruments = await slims_api_instance.get_aind_instrument(
+        input_id=instrument_id, partial_match=partial_match
+    )
+    if len(instruments) == 0:
+        raise HTTPException(status_code=404, detail="Not found")
+    else:
+        return JSONResponse(
+            status_code=400,
+            content=instruments,
+            headers={"X-Error-Message": "Models have not been validated."},
+        )

--- a/aind-metadata-service-server/src/aind_metadata_service_server/routes/slims.py
+++ b/aind-metadata-service-server/src/aind_metadata_service_server/routes/slims.py
@@ -1,0 +1,165 @@
+"""Module to handle slims endpoints"""
+
+from enum import Enum
+from typing import Optional
+
+from fastapi import APIRouter, Depends, HTTPException, Path, Query
+
+from aind_metadata_service_server.mappers.responses import map_to_response
+from aind_metadata_service_server.models import (
+    EcephysData,
+    HistologyData,
+    SpimData,
+)
+from aind_metadata_service_server.sessions import get_slims_api_instance
+
+router = APIRouter()
+
+
+class SlimsWorkflow(str, Enum):
+    """Available workflows that can be queried."""
+
+    SMARTSPIM_IMAGING = "smartspim_imaging"
+    HISTOLOGY = "histology"
+    WATER_RESTRICTION = "water_restriction"
+    VIRAL_INJECTIONS = "viral_injections"
+    ECEPHYS_SESSIONS = "ecephys_sessions"
+
+
+@router.get("/api/v2/slims/{workflow}")
+async def get_slims_workflow(
+    workflow: SlimsWorkflow = Path(
+        ...,
+        description="The SLIMS workflow to query.",
+    ),
+    subject_id: Optional[str] = Query(
+        None,
+        alias="subject_id",
+        description="Subject ID to filter the data.",
+        openapi_examples={
+            "smartspim_imaging_example": {
+                "summary": "SmartSPIM example subject ID",
+                "value": "744742",
+            },
+            "histology_example": {
+                "summary": "Histology example subject ID",
+                "value": "744742",
+            },
+            "water_restriction_example": {
+                "summary": "Water restriction example subject ID",
+                "value": "762287",
+            },
+            "viral_injections_example": {
+                "summary": "Viral injections subject ID (None)",
+                "value": None,
+            },
+            "ecephys_session_example": {
+                "summary": "Ecephys example subject ID",
+                "value": "750108",
+            },
+        },
+    ),
+    session_name: Optional[str] = Query(
+        None,
+        alias="session_name",
+        description="Name of the session (only for ecephys sessions).",
+        openapi_examples={
+            "none_example": {
+                "summary": "No session name (default)",
+                "value": None,
+            },
+            "ecephys_session_example": {
+                "summary": "Ecephys example session name",
+                "value": "ecephys_750108_2024-12-23_14-51-45",
+            },
+        },
+    ),
+    start_date_gte: Optional[str] = Query(
+        None,
+        alias="start_date_gte",
+        description="Experiment run created on or after. (ISO format)",
+        openapi_examples={
+            "smartspim_imaging_example": {
+                "summary": "SmartSPIM example start date",
+                "value": "2025-02-12",
+            },
+            "histology_example": {
+                "summary": "Histology example start date",
+                "value": "2025-02-06",
+            },
+            "water_restriction_example": {
+                "summary": "Water restriction example start date",
+                "value": "2024-12-13",
+            },
+            "viral_injections_example": {
+                "summary": "Viral injections example start date",
+                "value": "2025-04-22",
+            },
+            "ecephys_session_example": {
+                "summary": "Ecephys example start date",
+                "value": "2025-04-10",
+            },
+        },
+    ),
+    end_date_lte: Optional[str] = Query(
+        None,
+        alias="end_date_lte",
+        description="Experiment run created on or before. (ISO format)",
+        openapi_examples={
+            "smartspim_imaging_example": {
+                "summary": "SmartSPIM example end date",
+                "value": "2025-02-13",
+            },
+            "histology_example": {
+                "summary": "Histology example end date",
+                "value": "2025-02-07",
+            },
+            "water_restriction_example": {
+                "summary": "Water restriction example end date",
+                "value": "2024-12-14",
+            },
+            "viral_injections_example": {
+                "summary": "Viral injections example start date",
+                "value": "2025-04-25",
+            },
+            "ecephys_session_example": {
+                "summary": "Ecephys example end date",
+                "value": "2025-04-11",
+            },
+        },
+    ),
+    slims_api_instance=Depends(get_slims_api_instance),
+):
+    """
+    ## SLIMS
+    Return information from SLIMS.
+    """
+    kwargs = {
+        "subject_id": subject_id,
+        "start_date_gte": start_date_gte,
+        "end_date_lte": end_date_lte,
+        "_request_timeout": 240,
+    }
+    if workflow == SlimsWorkflow.ECEPHYS_SESSIONS:
+        kwargs["session_name"] = session_name
+    data = []
+    match workflow:
+        case SlimsWorkflow.ECEPHYS_SESSIONS:
+            data = await slims_api_instance.get_ecephys_sessions(**kwargs)
+            data = [EcephysData(**d.model_dump()) for d in data]
+        case SlimsWorkflow.HISTOLOGY:
+            data = await slims_api_instance.get_histology_data(**kwargs)
+            data = [HistologyData(**d.model_dump()) for d in data]
+        case SlimsWorkflow.SMARTSPIM_IMAGING:
+            data = await slims_api_instance.get_smartspim_imaging(**kwargs)
+            data = [SpimData(**d.model_dump()) for d in data]
+        case SlimsWorkflow.WATER_RESTRICTION:
+            data = await slims_api_instance.get_water_restriction_data(
+                **kwargs
+            )
+        case SlimsWorkflow.VIRAL_INJECTIONS:
+            data = await slims_api_instance.get_viral_injections(**kwargs)
+    if data == [] or data is None:
+        raise HTTPException(status_code=404, detail="Not found")
+    else:
+        return map_to_response(data)

--- a/aind-metadata-service-server/tests/resources/slims/instrument_example.json
+++ b/aind-metadata-service-server/tests/resources/slims/instrument_example.json
@@ -1,0 +1,633 @@
+{
+    "describedBy": "https://raw.githubusercontent.com/AllenNeuralDynamics/aind-data-schema/main/src/aind_data_schema/imaging/instrument.py",
+    "schema_version": "0.9.0",
+    "instrument_id": "440_SmartSPIM1_20240327",
+    "modification_date": "2024-03-27",
+    "instrument_type": "SmartSPIM",
+    "manufacturer": {
+      "name": "LifeCanvas",
+      "abbreviation": null,
+      "registry": null,
+      "registry_identifier": null
+    },
+    "temperature_control": false,
+    "humidity_control": false,
+    "optical_tables": [
+      {
+        "device_type": "OpticalTable",
+        "name": null,
+        "serial_number": "2008983",
+        "manufacturer": {
+          "name": "Technical Manufacturing Corporation",
+          "abbreviation": "TMC",
+          "registry": null,
+          "registry_identifier": null
+        },
+        "model": "63-533 micro-g",
+        "notes": null,
+        "length": 29.5,
+        "width": 35.5,
+        "table_size_unit": "inch",
+        "vibration_control": true
+      }
+    ],
+    "enclosure": null,
+    "objectives": [
+      {
+        "device_type": "Objective",
+        "name": null,
+        "serial_number": "Unknown",
+        "manufacturer": {
+          "name": "Thorlabs",
+          "abbreviation": null,
+          "registry": {
+            "name": "Research Organization Registry",
+            "abbreviation": "ROR"
+          },
+          "registry_identifier": "04gsnvb07"
+        },
+        "model": "TL4X-SAP",
+        "notes": "Thorlabs TL4X-SAP with LifeCanvas dipping cap and correction optics.",
+        "numerical_aperture": 0.2,
+        "magnification": 3.6,
+        "immersion": "multi"
+      },
+      {
+        "device_type": "Objective",
+        "name": null,
+        "serial_number": "Unknown",
+        "manufacturer": {
+          "name": "Thorlabs",
+          "abbreviation": null,
+          "registry": {
+            "name": "Research Organization Registry",
+            "abbreviation": "ROR"
+          },
+          "registry_identifier": "04gsnvb07"
+        },
+        "model": "TL2X-SAP",
+        "notes": null,
+        "numerical_aperture": 0.1,
+        "magnification": 1.6,
+        "immersion": "multi"
+      },
+      {
+        "device_type": "Objective",
+        "name": null,
+        "serial_number": "Unknown",
+        "manufacturer": {
+          "name": "Nikon",
+          "abbreviation": null,
+          "registry": {
+            "name": "Research Organization Registry",
+            "abbreviation": "ROR"
+          },
+          "registry_identifier": "0280y9h11"
+        },
+        "model": "MRD77220",
+        "notes": null,
+        "numerical_aperture": 0.8,
+        "magnification": 16,
+        "immersion": "water"
+      }
+    ],
+    "detectors": [
+      {
+        "device_type": "Detector",
+        "name": null,
+        "serial_number": "220302-SYS-060443",
+        "manufacturer": {
+          "name": "Hamamatsu",
+          "abbreviation": null,
+          "registry": {
+            "name": "Research Organization Registry",
+            "abbreviation": "ROR"
+          },
+          "registry_identifier": "03natb733"
+        },
+        "model": "C14440-20UP",
+        "notes": null,
+        "detector_type": "Camera",
+        "data_interface": "USB",
+        "cooling": "water",
+        "immersion": null,
+        "chroma": null,
+        "sensor_width": null,
+        "sensor_height": null,
+        "size_unit": "pixel",
+        "bit_depth": null,
+        "bin_mode": "none",
+        "bin_width": null,
+        "bin_height": null,
+        "bin_unit": "pixel",
+        "gain": null,
+        "crop_width": null,
+        "crop_height": null,
+        "crop_unit": "pixel"
+      }
+    ],
+    "light_sources": [
+      {
+        "device_type": "Laser",
+        "name": "Ex_445",
+        "serial_number": "VL08223M03",
+        "manufacturer": {
+          "name": "Vortran",
+          "abbreviation": null,
+          "registry": null,
+          "registry_identifier": null
+        },
+        "model": "Stradus",
+        "notes": "All lasers controlled via Vortran VersaLase System",
+        "wavelength": 445,
+        "wavelength_unit": "nanometer",
+        "maximum_power": 150,
+        "power_unit": "milliwatt",
+        "coupling": "Single-mode fiber",
+        "coupling_efficiency": null,
+        "coupling_efficiency_unit": "percent",
+        "item_number": null
+      },
+      {
+        "device_type": "Laser",
+        "name": "Ex_488",
+        "serial_number": "VL08223M03",
+        "manufacturer": {
+          "name": "Vortran",
+          "abbreviation": null,
+          "registry": null,
+          "registry_identifier": null
+        },
+        "model": "Stradus",
+        "notes": "All lasers controlled via Vortran VersaLase System",
+        "wavelength": 488,
+        "wavelength_unit": "nanometer",
+        "maximum_power": 150,
+        "power_unit": "milliwatt",
+        "coupling": "Single-mode fiber",
+        "coupling_efficiency": null,
+        "coupling_efficiency_unit": "percent",
+        "item_number": null
+      },
+      {
+        "device_type": "Laser",
+        "name": "Ex_561",
+        "serial_number": "",
+        "manufacturer": {
+          "name": "Other",
+          "abbreviation": null,
+          "registry": null,
+          "registry_identifier": null
+        },
+        "model": "Obis",
+        "notes": "All lasers controlled via Vortran VersaLase System",
+        "wavelength": 561,
+        "wavelength_unit": "nanometer",
+        "maximum_power": 150,
+        "power_unit": "milliwatt",
+        "coupling": "Single-mode fiber",
+        "coupling_efficiency": null,
+        "coupling_efficiency_unit": "percent",
+        "item_number": null
+      },
+      {
+        "device_type": "Laser",
+        "name": "Ex_594",
+        "serial_number": "VL08223M03",
+        "manufacturer": {
+          "name": "Vortran",
+          "abbreviation": null,
+          "registry": null,
+          "registry_identifier": null
+        },
+        "model": "Stradus",
+        "notes": "All lasers controlled via Vortran VersaLase System",
+        "wavelength": 594,
+        "wavelength_unit": "nanometer",
+        "maximum_power": 150,
+        "power_unit": "milliwatt",
+        "coupling": "Single-mode fiber",
+        "coupling_efficiency": null,
+        "coupling_efficiency_unit": "percent",
+        "item_number": null
+      },
+      {
+        "device_type": "Laser",
+        "name": "Ex_639",
+        "serial_number": "",
+        "manufacturer": {
+          "name": "Vortran",
+          "abbreviation": null,
+          "registry": null,
+          "registry_identifier": null
+        },
+        "model": "Stradus",
+        "notes": "All lasers controlled via Vortran VersaLase System",
+        "wavelength": 639,
+        "wavelength_unit": "nanometer",
+        "maximum_power": 160,
+        "power_unit": "milliwatt",
+        "coupling": "Single-mode fiber",
+        "coupling_efficiency": null,
+        "coupling_efficiency_unit": "percent",
+        "item_number": null
+      },
+      {
+        "device_type": "Laser",
+        "name": "Ex_665",
+        "serial_number": "VL08223M03",
+        "manufacturer": {
+          "name": "Vortran",
+          "abbreviation": null,
+          "registry": null,
+          "registry_identifier": null
+        },
+        "model": "Stradus",
+        "notes": "All lasers controlled via Vortran VersaLase System",
+        "wavelength": 665,
+        "wavelength_unit": "nanometer",
+        "maximum_power": 160,
+        "power_unit": "milliwatt",
+        "coupling": "Single-mode fiber",
+        "coupling_efficiency": null,
+        "coupling_efficiency_unit": "percent",
+        "item_number": null
+      }
+    ],
+    "lenses": null,
+    "fluorescence_filters": [
+      {
+        "device_type": "Filter",
+        "name": "Em_469",
+        "serial_number": "Unknown-1",
+        "manufacturer": {
+          "name": "Semrock",
+          "abbreviation": null,
+          "registry": null,
+          "registry_identifier": null
+        },
+        "model": "FF01-469/35-32",
+        "notes": null,
+        "filter_type": "Band pass",
+        "diameter": 32,
+        "width": null,
+        "height": null,
+        "size_unit": "millimeter",
+        "thickness": 2,
+        "thickness_unit": "millimeter",
+        "filter_wheel_index": 0,
+        "cut_off_wavelength": null,
+        "cut_on_wavelength": null,
+        "center_wavelength": null,
+        "wavelength_unit": "nanometer",
+        "description": null
+      },
+      {
+        "device_type": "Filter",
+        "name": "Em_525",
+        "serial_number": "Unknown-1",
+        "manufacturer": {
+          "name": "Semrock",
+          "abbreviation": null,
+          "registry": null,
+          "registry_identifier": null
+        },
+        "model": "FF03-525/50-32",
+        "notes": null,
+        "filter_type": "Band pass",
+        "diameter": 25,
+        "width": null,
+        "height": null,
+        "size_unit": "millimeter",
+        "thickness": 2,
+        "thickness_unit": "millimeter",
+        "filter_wheel_index": 1,
+        "cut_off_wavelength": null,
+        "cut_on_wavelength": null,
+        "center_wavelength": null,
+        "wavelength_unit": "nanometer",
+        "description": null
+      },
+      {
+        "device_type": "Filter",
+        "name": "Em_593",
+        "serial_number": "Unknown-2",
+        "manufacturer": {
+          "name": "Semrock",
+          "abbreviation": null,
+          "registry": null,
+          "registry_identifier": null
+        },
+        "model": "FF01-593/40-32",
+        "notes": null,
+        "filter_type": "Band pass",
+        "diameter": 32,
+        "width": null,
+        "height": null,
+        "size_unit": "millimeter",
+        "thickness": 2,
+        "thickness_unit": "millimeter",
+        "filter_wheel_index": 2,
+        "cut_off_wavelength": null,
+        "cut_on_wavelength": null,
+        "center_wavelength": null,
+        "wavelength_unit": "nanometer",
+        "description": null
+      },
+      {
+        "device_type": "Filter",
+        "name": "Em_624",
+        "serial_number": "Unknown-2",
+        "manufacturer": {
+          "name": "Semrock",
+          "abbreviation": null,
+          "registry": null,
+          "registry_identifier": null
+        },
+        "model": "FF01-624/40-32",
+        "notes": null,
+        "filter_type": "Band pass",
+        "diameter": 32,
+        "width": null,
+        "height": null,
+        "size_unit": "millimeter",
+        "thickness": 2,
+        "thickness_unit": "millimeter",
+        "filter_wheel_index": 3,
+        "cut_off_wavelength": null,
+        "cut_on_wavelength": null,
+        "center_wavelength": null,
+        "wavelength_unit": "nanometer",
+        "description": null
+      },
+      {
+        "device_type": "Filter",
+        "name": "Em_667",
+        "serial_number": "Unknown-3",
+        "manufacturer": {
+          "name": "Chroma",
+          "abbreviation": null,
+          "registry": null,
+          "registry_identifier": null
+        },
+        "model": "ET667/30m",
+        "notes": null,
+        "filter_type": "Band pass",
+        "diameter": 32,
+        "width": null,
+        "height": null,
+        "size_unit": "millimeter",
+        "thickness": 2,
+        "thickness_unit": "millimeter",
+        "filter_wheel_index": 4,
+        "cut_off_wavelength": null,
+        "cut_on_wavelength": null,
+        "center_wavelength": null,
+        "wavelength_unit": "nanometer",
+        "description": null
+      },
+      {
+        "device_type": "Filter",
+        "name": "Em_700",
+        "serial_number": "Unknown-2",
+        "manufacturer": {
+          "name": "Thorlabs",
+          "abbreviation": null,
+          "registry": {
+            "name": "Research Organization Registry",
+            "abbreviation": "ROR"
+          },
+          "registry_identifier": "04gsnvb07"
+        },
+        "model": "FELH0700",
+        "notes": null,
+        "filter_type": "Long pass",
+        "diameter": 32,
+        "width": null,
+        "height": null,
+        "size_unit": "millimeter",
+        "thickness": 2,
+        "thickness_unit": "millimeter",
+        "filter_wheel_index": 5,
+        "cut_off_wavelength": null,
+        "cut_on_wavelength": null,
+        "center_wavelength": null,
+        "wavelength_unit": "nanometer",
+        "description": null
+      }
+    ],
+    "motorized_stages": [
+      {
+        "device_type": "MotorizedStage",
+        "name": null,
+        "serial_number": "Unknown-0",
+        "manufacturer": {
+          "name": "Applied Scientific Instrumentation",
+          "abbreviation": "ASI",
+          "registry": null,
+          "registry_identifier": null
+        },
+        "model": "LS-100",
+        "notes": "Focus stage",
+        "travel": 100,
+        "travel_unit": "millimeter",
+        "firmware": null
+      },
+      {
+        "device_type": "MotorizedStage",
+        "name": null,
+        "serial_number": "Unknown-1",
+        "manufacturer": {
+          "name": "Other",
+          "abbreviation": null,
+          "registry": null,
+          "registry_identifier": null
+        },
+        "model": "L12-20F-4",
+        "notes": "Cylindrical lens #1",
+        "travel": 41,
+        "travel_unit": "millimeter",
+        "firmware": null
+      },
+      {
+        "device_type": "MotorizedStage",
+        "name": null,
+        "serial_number": "Unknown-2",
+        "manufacturer": {
+          "name": "Other",
+          "abbreviation": null,
+          "registry": null,
+          "registry_identifier": null
+        },
+        "model": "L12-20F-4",
+        "notes": "Cylindrical lens #2",
+        "travel": 41,
+        "travel_unit": "millimeter",
+        "firmware": null
+      },
+      {
+        "device_type": "MotorizedStage",
+        "name": null,
+        "serial_number": "Unknown-3",
+        "manufacturer": {
+          "name": "Other",
+          "abbreviation": null,
+          "registry": null,
+          "registry_identifier": null
+        },
+        "model": "L12-20F-4",
+        "notes": "Cylindrical lens #3",
+        "travel": 41,
+        "travel_unit": "millimeter",
+        "firmware": null
+      },
+      {
+        "device_type": "MotorizedStage",
+        "name": null,
+        "serial_number": "Unknown-4",
+        "manufacturer": {
+          "name": "Other",
+          "abbreviation": null,
+          "registry": null,
+          "registry_identifier": null
+        },
+        "model": "L12-20F-4",
+        "notes": "Cylindrical lens #4",
+        "travel": 41,
+        "travel_unit": "millimeter",
+        "firmware": null
+      }
+    ],
+    "scanning_stages": [
+      {
+        "device_type": "MotorizedStage",
+        "name": null,
+        "serial_number": "Unknown-0",
+        "manufacturer": {
+          "name": "Applied Scientific Instrumentation",
+          "abbreviation": "ASI",
+          "registry": null,
+          "registry_identifier": null
+        },
+        "model": "LS-50",
+        "notes": "Sample stage Z",
+        "travel": 50,
+        "travel_unit": "millimeter",
+        "firmware": null,
+        "stage_axis_direction": "Detection axis",
+        "stage_axis_name": "Z"
+      },
+      {
+        "device_type": "MotorizedStage",
+        "name": null,
+        "serial_number": "Unknown-1",
+        "manufacturer": {
+          "name": "Applied Scientific Instrumentation",
+          "abbreviation": "ASI",
+          "registry": null,
+          "registry_identifier": null
+        },
+        "model": "LS-50",
+        "notes": "Sample stage X",
+        "travel": 50,
+        "travel_unit": "millimeter",
+        "firmware": null,
+        "stage_axis_direction": "Illumination axis",
+        "stage_axis_name": "X"
+      },
+      {
+        "device_type": "MotorizedStage",
+        "name": null,
+        "serial_number": "Unknown-2",
+        "manufacturer": {
+          "name": "Applied Scientific Instrumentation",
+          "abbreviation": "ASI",
+          "registry": null,
+          "registry_identifier": null
+        },
+        "model": "LS-50",
+        "notes": "Sample stage Y",
+        "travel": 50,
+        "travel_unit": "millimeter",
+        "firmware": null,
+        "stage_axis_direction": "Perpendicular axis",
+        "stage_axis_name": "Y"
+      }
+    ],
+    "additional_devices": [
+      {
+        "device_type": "AdditionalImagingDevice",
+        "name": null,
+        "serial_number": "10436130",
+        "manufacturer": {
+          "name": "Julabo",
+          "abbreviation": null,
+          "registry": null,
+          "registry_identifier": null
+        },
+        "model": "200F",
+        "notes": null,
+        "type": "Other"
+      },
+      {
+        "device_type": "AdditionalImagingDevice",
+        "name": null,
+        "serial_number": "Unknown-1",
+        "manufacturer": {
+          "name": "Optotune",
+          "abbreviation": null,
+          "registry": null,
+          "registry_identifier": null
+        },
+        "model": "EL-16-40-TC",
+        "notes": null,
+        "type": "Other"
+      },
+      {
+        "device_type": "AdditionalImagingDevice",
+        "name": null,
+        "serial_number": "Unknown-2",
+        "manufacturer": {
+          "name": "Optotune",
+          "abbreviation": null,
+          "registry": null,
+          "registry_identifier": null
+        },
+        "model": "EL-16-40-TC",
+        "notes": null,
+        "type": "Other"
+      },
+      {
+        "device_type": "AdditionalImagingDevice",
+        "name": null,
+        "serial_number": "Unknown-1",
+        "manufacturer": {
+          "name": "LifeCanvas",
+          "abbreviation": null,
+          "registry": null,
+          "registry_identifier": null
+        },
+        "model": "Large-uncoated-glass",
+        "notes": null,
+        "type": "Sample Chamber"
+      }
+    ],
+    "calibration_date": null,
+    "calibration_data": null,
+    "com_ports": [
+      {
+        "hardware_name": "Laser Launch",
+        "com_port": "COM3"
+      },
+      {
+        "hardware_name": "Applied Scientific Instrumentation Tiger",
+        "com_port": "COM5"
+      },
+      {
+        "hardware_name": "MightyZap",
+        "com_port": "COM10"
+      }
+    ],
+    "daqs": null,
+    "notes": null
+}

--- a/aind-metadata-service-server/tests/resources/slims/rig_example.json
+++ b/aind-metadata-service-server/tests/resources/slims/rig_example.json
@@ -1,0 +1,737 @@
+{
+    "describedBy": "https://raw.githubusercontent.com/AllenNeuralDynamics/aind-data-schema/main/src/aind_data_schema/core/rig.py",
+    "schema_version": "1.1.1",
+    "rig_id": "323_EPHYS1_20250205",
+    "modification_date": "2025-02-05",
+    "mouse_platform": {
+      "device_type": "Wheel",
+      "name": "Running Wheel",
+      "serial_number": null,
+      "manufacturer": null,
+      "model": null,
+      "path_to_cad": null,
+      "port_index": null,
+      "additional_settings": {},
+      "notes": null,
+      "surface_material": null,
+      "date_surface_replaced": null,
+      "radius": "8.5",
+      "width": "5",
+      "size_unit": "millimeter",
+      "encoder": {
+        "device_type": "Encoder",
+        "name": "CUI Devices Encoder",
+        "serial_number": null,
+        "manufacturer": {
+          "name": "Same Sky",
+          "abbreviation": null,
+          "registry": null,
+          "registry_identifier": null
+        },
+        "model": "AMT102",
+        "path_to_cad": null,
+        "port_index": null,
+        "additional_settings": {},
+        "notes": null
+      },
+      "encoder_output": null,
+      "pulse_per_revolution": 32800,
+      "magnetic_brake": {
+        "device_type": "Brake",
+        "name": "Placid Industries magnetic brake",
+        "serial_number": null,
+        "manufacturer": {
+          "name": "Placid Industries",
+          "abbreviation": null,
+          "registry": null,
+          "registry_identifier": null
+        },
+        "model": "B1-2FM",
+        "path_to_cad": null,
+        "port_index": null,
+        "additional_settings": {},
+        "notes": null
+      },
+      "brake_output": null,
+      "torque_sensor": {
+        "device_type": "Torque sensor",
+        "name": "Transducer Techniques torque sensor",
+        "serial_number": null,
+        "manufacturer": {
+          "name": "Transducer Techniques",
+          "abbreviation": null,
+          "registry": null,
+          "registry_identifier": null
+        },
+        "model": "RTS-10",
+        "path_to_cad": null,
+        "port_index": null,
+        "additional_settings": {},
+        "notes": null
+      },
+      "torque_output": null
+    },
+    "stimulus_devices": [],
+    "cameras": [
+      {
+        "name": "Face Camera Assembly",
+        "camera_target": "Face side right",
+        "camera": {
+          "device_type": "Detector",
+          "name": "Face Camera",
+          "serial_number": "23022709",
+          "manufacturer": {
+            "name": "Teledyne FLIR",
+            "abbreviation": "FLIR",
+            "registry": {
+              "name": "Research Organization Registry",
+              "abbreviation": "ROR"
+            },
+            "registry_identifier": "01j1gwp17"
+          },
+          "model": "Blackfly S BFS-U3-04S2M",
+          "path_to_cad": null,
+          "port_index": null,
+          "additional_settings": {},
+          "notes": null,
+          "detector_type": "Camera",
+          "data_interface": "USB",
+          "cooling": "None",
+          "computer_name": "W10DT713669",
+          "frame_rate": null,
+          "frame_rate_unit": "hertz",
+          "immersion": null,
+          "chroma": "Monochrome",
+          "sensor_width": 720,
+          "sensor_height": 540,
+          "size_unit": "pixel",
+          "sensor_format": "1/2.9",
+          "sensor_format_unit": "inches",
+          "bit_depth": null,
+          "bin_mode": "None",
+          "bin_width": null,
+          "bin_height": null,
+          "bin_unit": "pixel",
+          "gain": null,
+          "crop_offset_x": null,
+          "crop_offset_y": null,
+          "crop_width": null,
+          "crop_height": null,
+          "crop_unit": "pixel",
+          "recording_software": null,
+          "driver": null,
+          "driver_version": null
+        },
+        "lens": {
+          "device_type": "Lens",
+          "name": "Fujinon CF16ZA-1S 16mm 23MP 1.1\" f/1.8 - f/16 C-Mount Lens",
+          "serial_number": null,
+          "manufacturer": {
+            "name": "Fujinon",
+            "abbreviation": null,
+            "registry": null,
+            "registry_identifier": null
+          },
+          "model": "CF16ZA-1S",
+          "path_to_cad": null,
+          "port_index": null,
+          "additional_settings": {},
+          "notes": null,
+          "focal_length": "16",
+          "focal_length_unit": "millimeter",
+          "size": null,
+          "lens_size_unit": "inch",
+          "optimized_wavelength_range": null,
+          "wavelength_unit": "nanometer",
+          "max_aperture": "f/1.8"
+        },
+        "filter": {
+          "device_type": "Filter",
+          "name": "LP715-37.5 Near-IR Longpass Filter",
+          "serial_number": null,
+          "manufacturer": {
+            "name": "Midwest Optical Systems, Inc.",
+            "abbreviation": "MidOpt",
+            "registry": null,
+            "registry_identifier": null
+          },
+          "model": null,
+          "path_to_cad": null,
+          "port_index": null,
+          "additional_settings": {},
+          "notes": null,
+          "filter_type": "Long pass",
+          "diameter": null,
+          "width": null,
+          "height": null,
+          "size_unit": "millimeter",
+          "thickness": null,
+          "thickness_unit": "millimeter",
+          "filter_wheel_index": null,
+          "cut_off_wavelength": null,
+          "cut_on_wavelength": null,
+          "center_wavelength": null,
+          "wavelength_unit": "nanometer",
+          "description": "Useful range 730 to 1100nm"
+        },
+        "position": null
+      }
+    ],
+    "enclosure": {
+      "device_type": "Enclosure",
+      "name": "Ephys enclosure",
+      "serial_number": null,
+      "manufacturer": {
+        "name": "Item",
+        "abbreviation": null,
+        "registry": null,
+        "registry_identifier": null
+      },
+      "model": null,
+      "path_to_cad": null,
+      "port_index": null,
+      "additional_settings": {},
+      "notes": null,
+      "size": {
+        "width": 131,
+        "length": 100,
+        "height": 120,
+        "unit": "centimeter"
+      },
+      "internal_material": "Aluminum",
+      "external_material": "Plastic",
+      "grounded": false,
+      "laser_interlock": true,
+      "air_filtration": false
+    },
+    "ephys_assemblies": [
+      {
+        "name": "Probe A ephys assembly",
+        "manipulator": {
+          "device_type": "Manipulator",
+          "name": "45881",
+          "serial_number": "33757",
+          "manufacturer": {
+            "name": "New Scale Technologies",
+            "abbreviation": null,
+            "registry": null,
+            "registry_identifier": null
+          },
+          "model": null,
+          "path_to_cad": null,
+          "port_index": null,
+          "additional_settings": {},
+          "notes": null
+        },
+        "probes": [
+          {
+            "device_type": "Ephys probe",
+            "name": "Probe A",
+            "serial_number": "22112104291",
+            "manufacturer": {
+              "name": "Interuniversity Microelectronics Center",
+              "abbreviation": "IMEC",
+              "registry": {
+                "name": "Research Organization Registry",
+                "abbreviation": "ROR"
+              },
+              "registry_identifier": "02kcbn207"
+            },
+            "model": null,
+            "path_to_cad": null,
+            "port_index": null,
+            "additional_settings": {},
+            "notes": null,
+            "probe_model": "Neuropixels Opto (Demonstrator)",
+            "lasers": [
+              {
+                "device_type": "Laser",
+                "name": "Oxxius Blue Laser",
+                "serial_number": "LAS-08787",
+                "manufacturer": {
+                  "name": "Oxxius",
+                  "abbreviation": null,
+                  "registry": null,
+                  "registry_identifier": null
+                },
+                "model": null,
+                "path_to_cad": null,
+                "port_index": null,
+                "additional_settings": {},
+                "notes": null,
+                "wavelength": 473,
+                "wavelength_unit": "nanometer",
+                "maximum_power": null,
+                "power_unit": "milliwatt",
+                "coupling": "Single-mode fiber",
+                "coupling_efficiency": null,
+                "coupling_efficiency_unit": "percent",
+                "item_number": null
+              },
+              {
+                "device_type": "Laser",
+                "name": "Oxxius Red Laser",
+                "serial_number": "LAS-08677",
+                "manufacturer": {
+                  "name": "Oxxius",
+                  "abbreviation": null,
+                  "registry": null,
+                  "registry_identifier": null
+                },
+                "model": null,
+                "path_to_cad": null,
+                "port_index": null,
+                "additional_settings": {},
+                "notes": null,
+                "wavelength": 638,
+                "wavelength_unit": "nanometer",
+                "maximum_power": null,
+                "power_unit": "milliwatt",
+                "coupling": "Single-mode fiber",
+                "coupling_efficiency": null,
+                "coupling_efficiency_unit": "percent",
+                "item_number": null
+              }
+            ],
+            "headstage": null
+          }
+        ]
+      }
+    ],
+    "fiber_assemblies": [],
+    "stick_microscopes": [
+      {
+        "name": "Probe camera 1",
+        "camera_target": "Brain surface",
+        "camera": {
+          "device_type": "Detector",
+          "name": "Probe Camera 1",
+          "serial_number": "22438385",
+          "manufacturer": {
+            "name": "Teledyne FLIR",
+            "abbreviation": "FLIR",
+            "registry": {
+              "name": "Research Organization Registry",
+              "abbreviation": "ROR"
+            },
+            "registry_identifier": "01j1gwp17"
+          },
+          "model": "Blackfly S BFS-U3-120S4C",
+          "path_to_cad": null,
+          "port_index": null,
+          "additional_settings": {},
+          "notes": null,
+          "detector_type": "Camera",
+          "data_interface": "USB",
+          "cooling": "None",
+          "computer_name": "W10DT713668",
+          "frame_rate": null,
+          "frame_rate_unit": "hertz",
+          "immersion": null,
+          "chroma": "Color",
+          "sensor_width": 4000,
+          "sensor_height": 3000,
+          "size_unit": "pixel",
+          "sensor_format": "1/1.7",
+          "sensor_format_unit": "inches",
+          "bit_depth": null,
+          "bin_mode": "None",
+          "bin_width": null,
+          "bin_height": null,
+          "bin_unit": "pixel",
+          "gain": null,
+          "crop_offset_x": null,
+          "crop_offset_y": null,
+          "crop_width": null,
+          "crop_height": null,
+          "crop_unit": "pixel",
+          "recording_software": null,
+          "driver": null,
+          "driver_version": null
+        },
+        "lens": {
+          "device_type": "Lens",
+          "name": "Probe lens",
+          "serial_number": null,
+          "manufacturer": {
+            "name": "Edmund Optics",
+            "abbreviation": null,
+            "registry": {
+              "name": "Research Organization Registry",
+              "abbreviation": "ROR"
+            },
+            "registry_identifier": "01j1gwp17"
+          },
+          "model": "InfiniProbe S-25",
+          "path_to_cad": null,
+          "port_index": null,
+          "additional_settings": {},
+          "notes": null,
+          "focal_length": null,
+          "focal_length_unit": "millimeter",
+          "size": null,
+          "lens_size_unit": "inch",
+          "optimized_wavelength_range": null,
+          "wavelength_unit": "nanometer",
+          "max_aperture": null
+        },
+        "filter": null,
+        "position": null
+      },
+      {
+        "name": "Probe camera 2",
+        "camera_target": "Brain surface",
+        "camera": {
+          "device_type": "Detector",
+          "name": "Probe Camera 2",
+          "serial_number": "20105611",
+          "manufacturer": {
+            "name": "Teledyne FLIR",
+            "abbreviation": "FLIR",
+            "registry": {
+              "name": "Research Organization Registry",
+              "abbreviation": "ROR"
+            },
+            "registry_identifier": "01j1gwp17"
+          },
+          "model": "Blackfly S BFS-U3-120S4C",
+          "path_to_cad": null,
+          "port_index": null,
+          "additional_settings": {},
+          "notes": null,
+          "detector_type": "Camera",
+          "data_interface": "USB",
+          "cooling": "None",
+          "computer_name": "W10DT713668",
+          "frame_rate": null,
+          "frame_rate_unit": "hertz",
+          "immersion": null,
+          "chroma": "Color",
+          "sensor_width": 4000,
+          "sensor_height": 3000,
+          "size_unit": "pixel",
+          "sensor_format": "1/1.7",
+          "sensor_format_unit": "inches",
+          "bit_depth": null,
+          "bin_mode": "None",
+          "bin_width": null,
+          "bin_height": null,
+          "bin_unit": "pixel",
+          "gain": null,
+          "crop_offset_x": null,
+          "crop_offset_y": null,
+          "crop_width": null,
+          "crop_height": null,
+          "crop_unit": "pixel",
+          "recording_software": null,
+          "driver": null,
+          "driver_version": null
+        },
+        "lens": {
+          "device_type": "Lens",
+          "name": "Probe lens",
+          "serial_number": null,
+          "manufacturer": {
+            "name": "Edmund Optics",
+            "abbreviation": null,
+            "registry": {
+              "name": "Research Organization Registry",
+              "abbreviation": "ROR"
+            },
+            "registry_identifier": "01j1gwp17"
+          },
+          "model": "InfiniProbe S-25",
+          "path_to_cad": null,
+          "port_index": null,
+          "additional_settings": {},
+          "notes": null,
+          "focal_length": null,
+          "focal_length_unit": "millimeter",
+          "size": null,
+          "lens_size_unit": "inch",
+          "optimized_wavelength_range": null,
+          "wavelength_unit": "nanometer",
+          "max_aperture": null
+        },
+        "filter": null,
+        "position": null
+      },
+      {
+        "name": "Probe camera 3",
+        "camera_target": "Brain surface",
+        "camera": {
+          "device_type": "Detector",
+          "name": "Probe Camera 3",
+          "serial_number": "22438379",
+          "manufacturer": {
+            "name": "Teledyne FLIR",
+            "abbreviation": "FLIR",
+            "registry": {
+              "name": "Research Organization Registry",
+              "abbreviation": "ROR"
+            },
+            "registry_identifier": "01j1gwp17"
+          },
+          "model": "Blackfly S BFS-U3-120S4C",
+          "path_to_cad": null,
+          "port_index": null,
+          "additional_settings": {},
+          "notes": null,
+          "detector_type": "Camera",
+          "data_interface": "USB",
+          "cooling": "None",
+          "computer_name": "W10DT713668",
+          "frame_rate": null,
+          "frame_rate_unit": "hertz",
+          "immersion": null,
+          "chroma": "Color",
+          "sensor_width": 4000,
+          "sensor_height": 3000,
+          "size_unit": "pixel",
+          "sensor_format": "1/1.7",
+          "sensor_format_unit": "inches",
+          "bit_depth": null,
+          "bin_mode": "None",
+          "bin_width": null,
+          "bin_height": null,
+          "bin_unit": "pixel",
+          "gain": null,
+          "crop_offset_x": null,
+          "crop_offset_y": null,
+          "crop_width": null,
+          "crop_height": null,
+          "crop_unit": "pixel",
+          "recording_software": null,
+          "driver": null,
+          "driver_version": null
+        },
+        "lens": {
+          "device_type": "Lens",
+          "name": "Probe lens",
+          "serial_number": null,
+          "manufacturer": {
+            "name": "Edmund Optics",
+            "abbreviation": null,
+            "registry": {
+              "name": "Research Organization Registry",
+              "abbreviation": "ROR"
+            },
+            "registry_identifier": "01j1gwp17"
+          },
+          "model": "InfiniProbe S-25",
+          "path_to_cad": null,
+          "port_index": null,
+          "additional_settings": {},
+          "notes": null,
+          "focal_length": null,
+          "focal_length_unit": "millimeter",
+          "size": null,
+          "lens_size_unit": "inch",
+          "optimized_wavelength_range": null,
+          "wavelength_unit": "nanometer",
+          "max_aperture": null
+        },
+        "filter": null,
+        "position": null
+      }
+    ],
+    "laser_assemblies": [
+      {
+        "name": "External 640 laser",
+        "manipulator": {
+          "device_type": "Manipulator",
+          "name": "45879",
+          "serial_number": "33711",
+          "manufacturer": {
+            "name": "New Scale Technologies",
+            "abbreviation": null,
+            "registry": null,
+            "registry_identifier": null
+          },
+          "model": null,
+          "path_to_cad": null,
+          "port_index": null,
+          "additional_settings": {},
+          "notes": null
+        },
+        "lasers": [
+          {
+            "device_type": "Laser",
+            "name": "Coherent Red Laser",
+            "serial_number": "M171024016",
+            "manufacturer": {
+              "name": "Coherent Scientific",
+              "abbreviation": null,
+              "registry": {
+                "name": "Research Organization Registry",
+                "abbreviation": "ROR"
+              },
+              "registry_identifier": "031tysd23"
+            },
+            "model": null,
+            "path_to_cad": null,
+            "port_index": null,
+            "additional_settings": {},
+            "notes": null,
+            "wavelength": 640,
+            "wavelength_unit": "nanometer",
+            "maximum_power": null,
+            "power_unit": "milliwatt",
+            "coupling": null,
+            "coupling_efficiency": null,
+            "coupling_efficiency_unit": "percent",
+            "item_number": null
+          }
+        ],
+        "collimator": {
+          "device_type": "Collimator",
+          "name": "Collimator",
+          "serial_number": null,
+          "manufacturer": {
+            "name": "Thorlabs",
+            "abbreviation": null,
+            "registry": {
+              "name": "Research Organization Registry",
+              "abbreviation": "ROR"
+            },
+            "registry_identifier": "04gsnvb07"
+          },
+          "model": "CFC2A",
+          "path_to_cad": null,
+          "port_index": null,
+          "additional_settings": {},
+          "notes": null
+        },
+        "fiber": {
+          "device_type": "Patch",
+          "name": "Patch cable",
+          "serial_number": null,
+          "manufacturer": null,
+          "model": null,
+          "path_to_cad": null,
+          "port_index": null,
+          "additional_settings": {},
+          "notes": null,
+          "core_diameter": "125",
+          "numerical_aperture": "0.12",
+          "photobleaching_date": null
+        }
+      }
+    ],
+    "patch_cords": [],
+    "light_sources": [
+      {
+        "device_type": "Light emitting diode",
+        "name": "Face cam illumination LED",
+        "serial_number": null,
+        "manufacturer": {
+          "name": "Thorlabs",
+          "abbreviation": null,
+          "registry": {
+            "name": "Research Organization Registry",
+            "abbreviation": "ROR"
+          },
+          "registry_identifier": "04gsnvb07"
+        },
+        "model": "M810L3",
+        "path_to_cad": null,
+        "port_index": null,
+        "additional_settings": {},
+        "notes": null,
+        "wavelength": 810,
+        "wavelength_unit": "nanometer",
+        "bandwidth": null,
+        "bandwidth_unit": "nanometer"
+      },
+      {
+        "device_type": "Light emitting diode",
+        "name": "Body cam illumination LED",
+        "serial_number": null,
+        "manufacturer": {
+          "name": "Thorlabs",
+          "abbreviation": null,
+          "registry": {
+            "name": "Research Organization Registry",
+            "abbreviation": "ROR"
+          },
+          "registry_identifier": "04gsnvb07"
+        },
+        "model": "M730L3",
+        "path_to_cad": null,
+        "port_index": null,
+        "additional_settings": {},
+        "notes": null,
+        "wavelength": 730,
+        "wavelength_unit": "nanometer",
+        "bandwidth": null,
+        "bandwidth_unit": "nanometer"
+      }
+    ],
+    "detectors": [],
+    "objectives": [],
+    "filters": [],
+    "lenses": [],
+    "digital_micromirror_devices": [],
+    "polygonal_scanners": [],
+    "pockels_cells": [],
+    "additional_devices": [],
+    "daqs": [
+      {
+        "device_type": "Harp device",
+        "name": "Harp Behavior",
+        "serial_number": null,
+        "manufacturer": {
+          "name": "Open Ephys Production Site",
+          "abbreviation": "OEPS",
+          "registry": {
+            "name": "Research Organization Registry",
+            "abbreviation": "ROR"
+          },
+          "registry_identifier": "007rkz355"
+        },
+        "model": null,
+        "path_to_cad": null,
+        "port_index": null,
+        "additional_settings": {},
+        "notes": null,
+        "data_interface": "USB",
+        "computer_name": "W10DT713669",
+        "channels": [
+          {
+            "channel_name": "DO1",
+            "device_name": "Face Camera",
+            "channel_type": "Digital Output",
+            "port": null,
+            "channel_index": null,
+            "sample_rate": null,
+            "sample_rate_unit": "hertz",
+            "event_based_sampling": null
+          }
+        ],
+        "firmware_version": null,
+        "hardware_version": null,
+        "harp_device_type": {
+          "whoami": 1216,
+          "name": "Behavior"
+        },
+        "core_version": "2.1",
+        "tag_version": null,
+        "is_clock_generator": true
+      }
+    ],
+    "calibrations": [],
+    "ccf_coordinate_transform": null,
+    "origin": null,
+    "rig_axes": null,
+    "modalities": [
+      {
+        "name": "Behavior videos",
+        "abbreviation": "behavior-videos"
+      },
+      {
+        "name": "Extracellular electrophysiology",
+        "abbreviation": "ecephys"
+      }
+    ],
+    "notes": null
+}

--- a/aind-metadata-service-server/tests/test_models.py
+++ b/aind-metadata-service-server/tests/test_models.py
@@ -1,8 +1,19 @@
 """Tests methods in models module"""
 
 import unittest
+from unittest.mock import MagicMock, patch
 
-from aind_metadata_service_server.models import HealthCheck
+from aind_slims_service_async_client.models import (
+    SlimsHistologyData,
+    SlimsSpimData,
+)
+
+from aind_metadata_service_server.models import (
+    EcephysData,
+    HealthCheck,
+    HistologyData,
+    SpimData,
+)
 
 
 class TestHealthCheck(unittest.TestCase):
@@ -13,6 +24,105 @@ class TestHealthCheck(unittest.TestCase):
 
         health_check = HealthCheck()
         self.assertEqual("OK", health_check.status)
+
+
+class TestSpimData(unittest.TestCase):
+    """Tests for SpimData"""
+
+    def test_parse_protocol_id(self):
+        """Tests parse_protocol_id method"""
+        protocol_html = '<a href="https://example.com">Example</a>'
+        slims_spim_data = SlimsSpimData(protocol_id=protocol_html)
+        spim_data = SpimData(**slims_spim_data.model_dump())
+        self.assertEqual("https://example.com", spim_data.protocol_id)
+
+    def test_parse_protocol_id_malformed_html(self):
+        """Tests parse_protocol_id method with malformed html"""
+        protocol_html = "<a>Missing Href</a>"
+        slims_spim_data = SlimsSpimData(protocol_id=protocol_html)
+        spim_data = SpimData(**slims_spim_data.model_dump())
+        self.assertIsNone(spim_data.protocol_id)
+
+    def test_parse_protocol_id_non_html(self):
+        """Tests parse_protocol_id method with non-html"""
+        protocol_html = "Not in HTML"
+        slims_spim_data = SlimsSpimData(protocol_id=protocol_html)
+        spim_data = SpimData(**slims_spim_data.model_dump())
+        self.assertEqual("Not in HTML", spim_data.protocol_id)
+
+    def test_parse_protocol_id_none(self):
+        """Tests parse_protocol_id method with None"""
+        slims_spim_data = SlimsSpimData(protocol_id=None)
+        spim_data = SpimData(**slims_spim_data.model_dump())
+        self.assertIsNone(spim_data.protocol_id)
+
+    @patch("logging.warning")
+    def test_parse_error(self, mock_log_warn: MagicMock):
+        """Tests parse_html when regular string passed in"""
+        slims_spim_data = {"protocol_id": 123}
+        spim_data = SpimData(**slims_spim_data)
+        self.assertIsNone(spim_data.protocol_id)
+        mock_log_warn.assert_called_once()
+
+
+class TestHistologyData(unittest.TestCase):
+    """Tests for HistologyData"""
+
+    def test_parse_protocol_id_html(self):
+        """Tests parse_protocol_id method"""
+        protocol_html = '<a href="https://example.com">Histology</a>'
+        slims_hist = SlimsHistologyData(protocol_id=protocol_html)
+        hist = HistologyData(**slims_hist.model_dump())
+        self.assertEqual(hist.protocol_id, "https://example.com")
+
+    def test_parse_protocol_id_malformed_html(self):
+        """Tests parse_protocol_id method with malformed html"""
+        protocol_html = "<a>Missing Href</a>"
+        slims_hist = SlimsHistologyData(protocol_id=protocol_html)
+        hist = HistologyData(**slims_hist.model_dump())
+        self.assertIsNone(hist.protocol_id)
+
+    def test_parse_protocol_id_non_html(self):
+        """Tests parse_protocol_id method with non-html"""
+        protocol_html = "Not in HTML"
+        slims_hist = SlimsHistologyData(protocol_id=protocol_html)
+        hist = HistologyData(**slims_hist.model_dump())
+        self.assertEqual(hist.protocol_id, "Not in HTML")
+
+    def test_parse_protocol_id_none(self):
+        """Tests parse_protocol_id method with None"""
+        slims_hist = SlimsHistologyData(protocol_id=None)
+        hist = HistologyData(**slims_hist.model_dump())
+        self.assertIsNone(hist.protocol_id)
+
+    @patch("logging.warning")
+    def test_parse_protocol_id_exception(self, mock_log_warn: MagicMock):
+        """Tests parse_html when regular string passed in"""
+        slims_hist = {"protocol_id": 123}
+        hist = HistologyData(**slims_hist)
+        self.assertIsNone(hist.protocol_id)
+        mock_log_warn.assert_called_once()
+
+
+class TestEcephysData(unittest.TestCase):
+    """Tests for EcephysData"""
+
+    def test_ecephys_data_with_stream_modules(self):
+        """Tests EcephysData initialization with stream modules"""
+        stream_module_dict = {
+            "ccf_coordinate_unit": "&mu;m",
+            "bregma_target_unit": "&mu;m",
+            "surface_z_unit": "&mu;m",
+            "manipulator_unit": "&mu;m",
+        }
+        ecephys_dict = {"stream_modules": [stream_module_dict]}
+        parsed = EcephysData(**ecephys_dict)
+        self.assertEqual(parsed.stream_modules[0].ccf_coordinate_unit, "μm")
+
+    def test_ecephys_data_with_no_stream_modules(self):
+        """Tests EcephysData initialization with no stream modules"""
+        parsed = EcephysData(**{"stream_modules": None})
+        self.assertIsNone(parsed.stream_modules)
 
 
 if __name__ == "__main__":

--- a/aind-metadata-service-server/tests/test_routes/test_rig_and_instrument.py
+++ b/aind-metadata-service-server/tests/test_routes/test_rig_and_instrument.py
@@ -1,0 +1,112 @@
+"""Test rig and instrument routes"""
+
+import json
+from pathlib import Path
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from fastapi.testclient import TestClient
+
+TEST_DIR = Path(__file__).parent / ".."
+TEST_RIG_JSON = TEST_DIR / "resources" / "slims" / "rig_example.json"
+TEST_INSTRUMENT_JSON = (
+    TEST_DIR / "resources" / "slims" / "instrument_example.json"
+)
+
+
+class TestRoute:
+    """Test responses."""
+
+    @patch(
+        "aind_slims_service_async_client.DefaultApi.get_aind_instrument",
+        new_callable=AsyncMock,
+    )
+    def test_get_rig(
+        self,
+        mock_slims_api_get: AsyncMock,
+        client: TestClient,
+    ):
+        """Tests a good response"""
+        with open(TEST_RIG_JSON) as f:
+            rig_data = json.load(f)
+        mock_slims_api_get.return_value = [rig_data]
+        response = client.get("/api/v2/rig/323_EPHYS1_20250205")
+
+        mock_slims_api_get.assert_called_once_with(
+            input_id="323_EPHYS1_20250205", partial_match=False
+        )
+        assert 400 == response.status_code
+        assert (
+            "Models have not been validated."
+            == response.headers["X-Error-Message"]
+        )
+
+    @patch(
+        "aind_slims_service_async_client.DefaultApi.get_aind_instrument",
+        new_callable=AsyncMock,
+    )
+    def test_get_instrument(
+        self,
+        mock_slims_api_get: AsyncMock,
+        client: TestClient,
+    ):
+        """Tests a good response"""
+        with open(TEST_INSTRUMENT_JSON) as f:
+            instrument_data = json.load(f)
+        mock_slims_api_get.return_value = [instrument_data]
+        response = client.get(
+            "/api/v2/instrument/440_SmartSPIM1_20240327?partial_match=True"
+        )
+
+        mock_slims_api_get.assert_called_once_with(
+            input_id="440_SmartSPIM1_20240327", partial_match=True
+        )
+        assert 400 == response.status_code
+        assert (
+            "Models have not been validated."
+            == response.headers["X-Error-Message"]
+        )
+
+    @patch(
+        "aind_slims_service_async_client.DefaultApi.get_aind_instrument",
+        new_callable=AsyncMock,
+    )
+    def test_get_rig_not_found(
+        self,
+        mock_slims_api_get: AsyncMock,
+        client: TestClient,
+    ):
+        """Tests 404 response when rig is not found"""
+        mock_slims_api_get.return_value = []
+
+        response = client.get("/api/v2/rig/nonexistent_rig")
+
+        mock_slims_api_get.assert_called_once_with(
+            input_id="nonexistent_rig", partial_match=False
+        )
+        assert 404 == response.status_code
+        assert response.json()["detail"] == "Not found"
+
+    @patch(
+        "aind_slims_service_async_client.DefaultApi.get_aind_instrument",
+        new_callable=AsyncMock,
+    )
+    def test_get_instrument_not_found(
+        self,
+        mock_slims_api_get: AsyncMock,
+        client: TestClient,
+    ):
+        """Tests 404 response when instrument is not found"""
+        mock_slims_api_get.return_value = []
+
+        response = client.get("/api/v2/instrument/nonexistent_instrument")
+
+        mock_slims_api_get.assert_called_once_with(
+            input_id="nonexistent_instrument", partial_match=False
+        )
+        assert 404 == response.status_code
+        assert response.json()["detail"] == "Not found"
+
+
+if __name__ == "__main__":
+    pytest.main([__file__])

--- a/aind-metadata-service-server/tests/test_routes/test_slims.py
+++ b/aind-metadata-service-server/tests/test_routes/test_slims.py
@@ -1,0 +1,176 @@
+"""Test slims routes"""
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from aind_slims_service_async_client import models
+from fastapi.testclient import TestClient
+
+
+class TestRoute:
+    """Test responses."""
+
+    @patch("aind_slims_service_async_client.DefaultApi.get_ecephys_sessions")
+    def test_get_ecephys_workflow(
+        self,
+        mock_slims_api_get: AsyncMock,
+        client: TestClient,
+    ):
+        """Tests a good response and correct parsing of stream_modules."""
+        mock_slims_api_get.return_value = [
+            models.slims_ecephys_data.SlimsEcephysData(
+                subject_id="12345",
+                stream_modules=[
+                    {
+                        "ccf_coordinate_unit": "&mu;m",
+                        "bregma_target_unit": "&mu;m",
+                        "surface_z_unit": "&mu;m",
+                        "manipulator_unit": "&mu;m",
+                    }
+                ],
+            )
+        ]
+        response = client.get(
+            "/api/v2/slims/ecephys_sessions?subject_id=12345"
+        )
+        mock_slims_api_get.assert_called_once_with(
+            subject_id="12345",
+            start_date_gte=None,
+            end_date_lte=None,
+            _request_timeout=240,
+            session_name=None,
+        )
+        assert 200 == response.status_code
+        data = response.json()[0]
+        # Check that micrometer units are unescaped
+        assert data["stream_modules"][0]["ccf_coordinate_unit"] == "μm"
+        assert data["stream_modules"][0]["bregma_target_unit"] == "μm"
+        assert data["stream_modules"][0]["surface_z_unit"] == "μm"
+        assert data["stream_modules"][0]["manipulator_unit"] == "μm"
+
+    @patch("aind_slims_service_async_client.DefaultApi.get_smartspim_imaging")
+    def test_get_imaging_workflow(
+        self,
+        mock_slims_api_get: AsyncMock,
+        client: TestClient,
+    ):
+        """Tests a good response and protocol_id HTML parsing."""
+        protocol_html = '<a href="https://example.com">Example</a>'
+        mock_slims_api_get.return_value = [
+            models.slims_spim_data.SlimsSpimData(
+                subject_id="12345", protocol_id=protocol_html
+            )
+        ]
+        response = client.get(
+            "/api/v2/slims/smartspim_imaging?subject_id=12345"
+        )
+        mock_slims_api_get.assert_called_once_with(
+            subject_id="12345",
+            start_date_gte=None,
+            end_date_lte=None,
+            _request_timeout=240,
+        )
+        assert 200 == response.status_code
+        data = response.json()[0]
+        assert data["protocol_id"] == "https://example.com"
+
+    @patch("aind_slims_service_async_client.DefaultApi.get_viral_injections")
+    def test_get_viral_injections_workflow(
+        self,
+        mock_slims_api_get: AsyncMock,
+        client: TestClient,
+    ):
+        """Tests a good response"""
+        mock_slims_api_get.return_value = [
+            models.slims_viral_injection_data.SlimsViralInjectionData(
+                subject_id="12345"
+            )
+        ]
+        response = client.get(
+            "/api/v2/slims/viral_injections?subject_id=12345"
+        )
+        mock_slims_api_get.assert_called_once_with(
+            subject_id="12345",
+            start_date_gte=None,
+            end_date_lte=None,
+            _request_timeout=240,
+        )
+        assert 200 == response.status_code
+
+    @patch(
+        "aind_slims_service_async_client.DefaultApi.get_water_restriction_data"
+    )
+    def test_get_water_restriction_workflow(
+        self,
+        mock_slims_api_get: AsyncMock,
+        client: TestClient,
+    ):
+        """Tests a good response"""
+        mock_slims_api_get.return_value = [
+            models.slims_water_restriction_data.SlimsWaterRestrictionData(
+                subject_id="12345"
+            )
+        ]
+        response = client.get(
+            "/api/v2/slims/water_restriction?subject_id=12345"
+        )
+        mock_slims_api_get.assert_called_once_with(
+            subject_id="12345",
+            start_date_gte=None,
+            end_date_lte=None,
+            _request_timeout=240,
+        )
+        assert 200 == response.status_code
+
+    @patch("aind_slims_service_async_client.DefaultApi.get_histology_data")
+    def test_get_histology_workflow(
+        self,
+        mock_slims_api_get: AsyncMock,
+        client: TestClient,
+    ):
+        """Tests a good response and protocol_id HTML parsing."""
+        protocol_html = '<a href="https://histology.com">Histology</a>'
+        mock_slims_api_get.return_value = [
+            models.slims_histology_data.SlimsHistologyData(
+                subject_id="12345", protocol_id=protocol_html
+            )
+        ]
+        response = client.get("/api/v2/slims/histology?subject_id=12345")
+        mock_slims_api_get.assert_called_once_with(
+            subject_id="12345",
+            start_date_gte=None,
+            end_date_lte=None,
+            _request_timeout=240,
+        )
+        assert 200 == response.status_code
+        data = response.json()[0]
+        assert data["protocol_id"] == "https://histology.com"
+
+    @patch("aind_slims_service_async_client.DefaultApi.get_histology_data")
+    def test_get_no_data(
+        self,
+        mock_slims_api_get: AsyncMock,
+        client: TestClient,
+    ):
+        """Tests a Not Found Response"""
+        mock_slims_api_get.return_value = []
+        response = client.get("/api/v2/slims/histology?subject_id=12345")
+        mock_slims_api_get.assert_called_once_with(
+            subject_id="12345",
+            start_date_gte=None,
+            end_date_lte=None,
+            _request_timeout=240,
+        )
+        assert 404 == response.status_code
+
+    def test_non_workflow_response(
+        self,
+        client: TestClient,
+    ):
+        """Tests a non-existent workflow"""
+        response = client.get("/api/v2/slims/NO_WORKFLOW")
+        assert 422 == response.status_code
+
+
+if __name__ == "__main__":
+    pytest.main([__file__])


### PR DESCRIPTION
breaking up #558. This PR handles the endpoints retrieving from SLIMS.

- adds api/v2/slims/..., api/v2/rig, and api/v2/instrument endpoints
- api/v2/rig and api/v2/instrument endpoints do not validate json fetched from SLIMS (data-schema v2 vastly changed and all of the data stored in SLIMS is V1)
- Adds example JSONs from SLIMS for testing
