### PR TITLE
feat: maps legacy inj materials, mgi, perfusion to api/v2

### DIFF
--- a/aind-metadata-service-server/src/aind_metadata_service_server/main.py
+++ b/aind-metadata-service-server/src/aind_metadata_service_server/main.py
@@ -13,6 +13,9 @@ from aind_metadata_service_server.routes import (
     funding,
     healthcheck,
     index,
+    injection_materials,
+    mgi_allele,
+    perfusion,
     procedures,
     rig_and_instrument,
     slims,
@@ -58,6 +61,9 @@ app.include_router(procedures.router)
 app.include_router(funding.router)
 app.include_router(slims.router)
 app.include_router(rig_and_instrument.router)
+app.include_router(perfusion.router)
+app.include_router(mgi_allele.router)
+app.include_router(injection_materials.router)
 app.include_router(index.router)
 
 # Clean up the methods names that is generated in the client code

--- a/aind-metadata-service-server/src/aind_metadata_service_server/mappers/responses.py
+++ b/aind-metadata-service-server/src/aind_metadata_service_server/mappers/responses.py
@@ -25,7 +25,10 @@ def map_to_response(model: Union[BaseModel, List[BaseModel]]) -> JSONResponse:
             content = validate.model_dump(mode="json")
         return JSONResponse(content=content)
     except ValidationError as e:
-        content = model.model_dump(mode="json")
+        if isinstance(model, list):
+            content = [item.model_dump(mode="json") for item in model]
+        else:
+            content = model.model_dump(mode="json")
         errors = e.json()
         logging.warning(errors)
         return JSONResponse(

--- a/aind-metadata-service-server/src/aind_metadata_service_server/routes/injection_materials.py
+++ b/aind-metadata-service-server/src/aind_metadata_service_server/routes/injection_materials.py
@@ -1,0 +1,56 @@
+"""Module to handle injection_material endpoints"""
+
+from typing import List
+
+from aind_tars_service_async_client import PrepLotData
+from fastapi import APIRouter, Depends, HTTPException, Path
+
+from aind_metadata_service_server.mappers.injection_materials import (
+    InjectionMaterialsMapper,
+)
+from aind_metadata_service_server.mappers.responses import map_to_response
+from aind_metadata_service_server.sessions import get_tars_api_instance
+
+router = APIRouter()
+
+
+@router.get("/api/v2/tars_injection_materials/{prep_lot_number}")
+async def get_injection_materials(
+    prep_lot_number: str = Path(
+        ...,
+        openapi_examples={
+            "default": {
+                "summary": "A sample prep lot number",
+                "description": "Example prep lot number for TARS",
+                "value": "VT3214G",
+            }
+        },
+    ),
+    tars_api_instance=Depends(get_tars_api_instance),
+):
+    """
+    ## Injection Materials
+    Return Injection Materials metadata.
+    """
+    tars_prep_lot_response: List[PrepLotData] = (
+        await tars_api_instance.get_viral_prep_lots(
+            lot=prep_lot_number, _request_timeout=10
+        )
+    )
+    mappers = [
+        InjectionMaterialsMapper(tars_prep_lot_data=prep_lot_data)
+        for prep_lot_data in tars_prep_lot_response
+    ]
+    for mapper in mappers:
+        virus_id = mapper.virus_id
+        if virus_id:
+            virus_response = await tars_api_instance.get_viruses(
+                name=virus_id, _request_timeout=10
+            )
+            mapper.tars_virus_data = virus_response
+
+    viral_materials = [m.map_to_viral_material_information() for m in mappers]
+    if len(viral_materials) == 0:
+        raise HTTPException(status_code=404, detail="Not found")
+    else:
+        return map_to_response(viral_materials)

--- a/aind-metadata-service-server/src/aind_metadata_service_server/routes/mgi_allele.py
+++ b/aind-metadata-service-server/src/aind_metadata_service_server/routes/mgi_allele.py
@@ -1,0 +1,50 @@
+"""Module to handle allele endpoints"""
+
+from fastapi import APIRouter, Depends, HTTPException, Path
+
+from aind_metadata_service_server.mappers.mgi_allele import MgiMapper
+from aind_metadata_service_server.mappers.responses import map_to_response
+from aind_metadata_service_server.sessions import get_mgi_api_instance
+
+router = APIRouter()
+
+
+@router.get("/api/v2/mgi_allele/{allele_name}")
+async def get_mgi_allele(
+    allele_name: str = Path(
+        ...,
+        openapi_examples={
+            "cre_line": {
+                "summary": "Cre line example",
+                "description": "Example using a Cre recombinase line",
+                "value": "Parvalbumin-IRES-Cre",
+            },
+            "gene_symbol": {
+                "summary": "Gene symbol example",
+                "description": "Example using a gene symbol",
+                "value": "Pvalb",
+            },
+        },
+    ),
+    mgi_api_instance=Depends(get_mgi_api_instance),
+):
+    """
+    ## MGI Allele
+    Return MGI Allele metadata.
+    """
+    mgi_response = await mgi_api_instance.get_allele_info(
+        allele_name=allele_name, _request_timeout=10
+    )
+    mappers = [
+        MgiMapper(mgi_summary_row=mgi_summary_row)
+        for mgi_summary_row in mgi_response
+    ]
+    pid_models = [
+        mapper.map_to_aind_pid_name()
+        for mapper in mappers
+        if mapper.map_to_aind_pid_name()
+    ]
+    if len(pid_models) == 0:
+        raise HTTPException(status_code=404, detail="Not found")
+    else:
+        return map_to_response(pid_models)

--- a/aind-metadata-service-server/src/aind_metadata_service_server/routes/perfusion.py
+++ b/aind-metadata-service-server/src/aind_metadata_service_server/routes/perfusion.py
@@ -1,0 +1,41 @@
+"""Module to handle perfusions endpoints"""
+
+from fastapi import APIRouter, Depends, HTTPException, Path
+
+from aind_metadata_service_server.mappers.perfusion import PerfusionMapper
+from aind_metadata_service_server.mappers.responses import map_to_response
+from aind_metadata_service_server.sessions import get_smartsheet_api_instance
+
+router = APIRouter()
+
+
+@router.get("/api/v2/perfusions/{subject_id}")
+async def get_perfusions(
+    subject_id: str = Path(
+        ...,
+        openapi_examples={
+            "default": {
+                "summary": "A sample subject id",
+                "description": "Example subject id",
+                "value": "689418",
+            }
+        },
+    ),
+    smartsheet_api_instance=Depends(get_smartsheet_api_instance),
+):
+    """
+    ## Perfusions
+    Return Perfusions metadata.
+    """
+    perfusions_response = await smartsheet_api_instance.get_perfusions(
+        subject_id, _request_timeout=10
+    )
+    mappers = [
+        PerfusionMapper(smartsheet_perfusion=smartsheet_perfusion)
+        for smartsheet_perfusion in perfusions_response
+    ]
+    perfusions = [mapper.map_to_aind_surgery() for mapper in mappers]
+    if len(perfusions) == 0:
+        raise HTTPException(status_code=404, detail="Not found")
+    else:
+        return map_to_response(perfusions)

--- a/aind-metadata-service-server/tests/test_mappers/test_responses.py
+++ b/aind-metadata-service-server/tests/test_mappers/test_responses.py
@@ -69,6 +69,27 @@ class TestResponses(unittest.TestCase):
             json.loads(response.body.decode("utf-8")),
         )
 
+    def test_map_multiple_to_400_response(self):
+        """Tests invalid list of models is mapped to a 400 response."""
+
+        models = [
+            ExampleModel.model_construct(name=None, id=123),
+            ExampleModel.model_construct(name="def", id=None, val=None),
+            ExampleModel.model_construct(name="ghi", id=None),
+        ]
+        response = map_to_response(model=models)
+        self.assertEqual(400, response.status_code)
+
+        expected_content = [
+            {"name": None, "id": 123, "val": "default_value"},
+            {"name": "def", "id": None, "val": None},
+            {"name": "ghi", "id": None, "val": "default_value"},
+        ]
+        self.assertEqual(
+            expected_content,
+            json.loads(response.body.decode("utf-8")),
+        )
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/aind-metadata-service-server/tests/test_routes/test_injection_materials.py
+++ b/aind-metadata-service-server/tests/test_routes/test_injection_materials.py
@@ -1,0 +1,63 @@
+"""Test injection_materials routes"""
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from aind_tars_service_async_client import (
+    Alias,
+    PrepLotData,
+    ViralPrep,
+    VirusData,
+)
+from fastapi.testclient import TestClient
+
+
+class TestRoute:
+    """Test responses."""
+
+    @patch("aind_tars_service_async_client.DefaultApi.get_viruses")
+    @patch("aind_tars_service_async_client.DefaultApi.get_viral_prep_lots")
+    def test_get_injection_materials(
+        self,
+        mock_tars_api_get_viral_prep_lots: AsyncMock,
+        mock_tars_api_get_viruses: AsyncMock,
+        client: TestClient,
+    ):
+        """Tests an invalid model response"""
+        mock_tars_api_get_viral_prep_lots.return_value = [
+            PrepLotData(
+                lot="abc",
+                viral_prep=ViralPrep(
+                    virus=VirusData(
+                        aliases=[Alias(is_preferred=True, name="v_123")]
+                    )
+                ),
+            )
+        ]
+        mock_tars_api_get_viruses.return_value = []
+        response = client.get("/api/v2/tars_injection_materials/abc")
+        mock_tars_api_get_viral_prep_lots.assert_called_once_with(
+            lot="abc", _request_timeout=10
+        )
+        mock_tars_api_get_viruses.assert_called_once_with(
+            name="v_123", _request_timeout=10
+        )
+        assert 400 == response.status_code
+
+    @patch("aind_tars_service_async_client.DefaultApi.get_viral_prep_lots")
+    def test_get_injection_materials_not_found(
+        self,
+        mock_tars_api_get_viral_prep_lots: AsyncMock,
+        client: TestClient,
+    ):
+        """Tests a 404 response when no injection materials are found"""
+        mock_tars_api_get_viral_prep_lots.return_value = []
+        response = client.get("/api/v2/tars_injection_materials/unknown_lot")
+        mock_tars_api_get_viral_prep_lots.assert_called_once_with(
+            lot="unknown_lot", _request_timeout=10
+        )
+        assert 404 == response.status_code
+
+
+if __name__ == "__main__":
+    pytest.main([__file__])

--- a/aind-metadata-service-server/tests/test_routes/test_mgi_allele.py
+++ b/aind-metadata-service-server/tests/test_routes/test_mgi_allele.py
@@ -1,0 +1,71 @@
+"""Test MGI allele routes"""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+from aind_mgi_service_async_client.models import MgiSummaryRow
+from fastapi.testclient import TestClient
+
+
+class TestRoute:
+    """Test responses."""
+
+    @patch("aind_mgi_service_async_client.DefaultApi.get_allele_info")
+    def test_get_mgi_allele(
+        self,
+        mock_mgi_api_get: MagicMock,
+        client: TestClient,
+    ):
+        """Tests a good response"""
+        mock_mgi_api_get.return_value = [
+            MgiSummaryRow(
+                detail_uri="/allele/MGI:5558086",
+                feature_type="Targeted allele",
+                strand=None,
+                chromosome="9",
+                stars="****",
+                best_match_text="Ai93",
+                best_match_type="Synonym",
+                name=(
+                    "intergenic site 7; " "targeted mutation 93, Hongkui Zeng"
+                ),
+                location="syntenic",
+                symbol="Igs7<tm93.1(tetO-GCaMP6f)Hze>",
+            ),
+            MgiSummaryRow(
+                detail_uri="/allele/MGI:1234567",
+                feature_type="Gene",
+                strand=None,
+                chromosome="X",
+                stars="**",
+                best_match_text="Test",
+                best_match_type="Gene",
+                name="Test gene",
+                location="syntenic",
+                symbol="TestGene",
+            ),
+        ]
+
+        response = client.get("/api/v2/mgi_allele/Parvalbumin-IRES-Cre")
+
+        assert 200 == response.status_code
+        assert 1 == len(mock_mgi_api_get.mock_calls)
+
+        mock_mgi_api_get.assert_called_once_with(
+            allele_name="Parvalbumin-IRES-Cre", _request_timeout=10
+        )
+
+    @patch("aind_mgi_service_async_client.DefaultApi.get_allele_info")
+    def test_get_mgi_allele_not_found(
+        self,
+        mock_mgi_api_get: MagicMock,
+        client: TestClient,
+    ):
+        """Tests 404 when no MGI alleles are found"""
+        mock_mgi_api_get.return_value = []
+        response = client.get("/api/v2/mgi_allele/unknown_allele")
+        assert 404 == response.status_code
+
+
+if __name__ == "__main__":
+    pytest.main([__file__])

--- a/aind-metadata-service-server/tests/test_routes/test_perfusion.py
+++ b/aind-metadata-service-server/tests/test_routes/test_perfusion.py
@@ -1,0 +1,60 @@
+"""Test perfusion routes"""
+
+from datetime import date
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from aind_smartsheet_service_async_client.models import PerfusionsModel
+from fastapi.testclient import TestClient
+
+
+class TestRoute:
+    """Test responses."""
+
+    @patch("aind_smartsheet_service_async_client.DefaultApi.get_perfusions")
+    def test_get_perfusion(
+        self,
+        mock_get_perfusions: AsyncMock,
+        client: TestClient,
+    ):
+        """Tests successful perfusion retrieval"""
+        mock_get_perfusions.return_value = [
+            PerfusionsModel(
+                subject_id="689418.0",
+                var_date=date(2023, 10, 2),
+                experimenter="Person S",
+                iacuc_protocol=(
+                    "2109 - Analysis of brain - wide neural circuits in the"
+                    " mouse"
+                ),
+                animal_weight_prior__g="22.0",
+                output_specimen_id_s="689418.0",
+                postfix_solution="1xPBS",
+                notes="Good",
+            ),
+        ]
+        response = client.get("/api/v2/perfusions/689418")
+        assert 200 == response.status_code
+        assert 1 == len(mock_get_perfusions.mock_calls)
+        mock_get_perfusions.assert_called_once_with(
+            "689418", _request_timeout=10
+        )
+
+    @patch("aind_smartsheet_service_async_client.DefaultApi.get_perfusions")
+    def test_get_perfusion_not_found(
+        self,
+        mock_get_perfusions: AsyncMock,
+        client: TestClient,
+    ):
+        """Tests 404 when no perfusions are found"""
+        mock_get_perfusions.return_value = []
+        response = client.get("/api/v2/perfusions/unknown_subject")
+        assert 404 == response.status_code
+        assert 1 == len(mock_get_perfusions.mock_calls)
+        mock_get_perfusions.assert_called_once_with(
+            "unknown_subject", _request_timeout=10
+        )
+
+
+if __name__ == "__main__":
+    pytest.main([__file__])


### PR DESCRIPTION
breaking up #558 

This PR: 
- Adds routes for intended measurements, protocols, and session_json
- fix in response handler to handle validation of multiple models 