### PR TITLE
fix: set breeding group to None

### DIFF
--- a/aind-metadata-service-server/src/aind_metadata_service_server/mappers/las2020.py
+++ b/aind-metadata-service-server/src/aind_metadata_service_server/mappers/las2020.py
@@ -17,7 +17,7 @@ from aind_data_schema.components.injection_procedures import (
 from aind_data_schema.components.subject_procedures import Surgery
 from aind_data_schema_models.coordinates import AnatomicalRelative
 from aind_data_schema_models.mouse_anatomy import InjectionTargets
-from aind_data_schema_models.units import VolumeUnit, TimeUnit
+from aind_data_schema_models.units import TimeUnit, VolumeUnit
 from aind_sharepoint_service_async_client.models import (
     Las2020List,
     LASDoseroute,

--- a/aind-metadata-service-server/src/aind_metadata_service_server/mappers/subject.py
+++ b/aind-metadata-service-server/src/aind_metadata_service_server/mappers/subject.py
@@ -147,8 +147,6 @@ class SubjectMapper:
         BreedingInfo | None
         """
         labtracks_subject = self.labtracks_subject
-        # labtracks_subject.group_name functionality changed
-        breeding_group = None
         paternal_id = labtracks_subject.paternal_id
         if labtracks_subject.paternal_class_values:
             paternal_genotype = (
@@ -164,15 +162,23 @@ class SubjectMapper:
         else:
             maternal_genotype = None
         breeding_values = [
-            breeding_group,
             paternal_id,
             paternal_genotype,
             maternal_id,
             maternal_genotype,
         ]
-        if any(value is not None for value in breeding_values):
+        # breeding_group will be deprecated in schema, so setting to empty
+        if None not in breeding_values:
+            return BreedingInfo(
+                breeding_group="",
+                paternal_id=paternal_id,
+                paternal_genotype=paternal_genotype,
+                maternal_id=maternal_id,
+                maternal_genotype=maternal_genotype,
+            )
+        elif any(value is not None for value in breeding_values):
             return BreedingInfo.model_construct(
-                breeding_group=breeding_group,
+                breeding_group="",
                 paternal_id=paternal_id,
                 paternal_genotype=paternal_genotype,
                 maternal_id=maternal_id,

--- a/aind-metadata-service-server/tests/test_mappers/test_subject.py
+++ b/aind-metadata-service-server/tests/test_mappers/test_subject.py
@@ -86,8 +86,8 @@ class TestSubjectMapper(unittest.TestCase):
             id="123",
         )
         self.assertEqual(
-            BreedingInfo.model_construct(
-                breeding_group=None,
+            BreedingInfo(
+                breeding_group="",
                 paternal_id="B",
                 paternal_genotype="C",
                 maternal_id="D",
@@ -97,7 +97,7 @@ class TestSubjectMapper(unittest.TestCase):
         )
         self.assertEqual(
             BreedingInfo.model_construct(
-                breeding_group=None,
+                breeding_group="",
                 maternal_id="D",
                 maternal_genotype=None,
                 paternal_id=None,
@@ -207,9 +207,9 @@ class TestSubjectMapper(unittest.TestCase):
                 species=Species.HOUSE_MOUSE,
                 alleles=[],
                 genotype="Pvalb-IRES-Cre/wt;RCL-somBiPoles_mCerulean-WPRE/wt",
-                breeding_info=BreedingInfo.model_construct(
+                breeding_info=BreedingInfo(
                     object_type="Breeding info",
-                    breeding_group=None,
+                    breeding_group="",
                     maternal_id="615310",
                     maternal_genotype="Pvalb-IRES-Cre/wt",
                     paternal_id="623236",

--- a/aind-metadata-service-server/tests/test_routes/test_subject.py
+++ b/aind-metadata-service-server/tests/test_routes/test_subject.py
@@ -69,7 +69,7 @@ class TestRoute:
         ]
         mock_mg_api_get.return_value = []
         response = client.get("api/v2/subject/632269")
-        assert 400 == response.status_code
+        assert 200 == response.status_code
         assert 1 == len(mock_lb_api_get.mock_calls)
         assert 2 == len(mock_mg_api_get.mock_calls)
 


### PR DESCRIPTION
closes #583 
In Labtracks, the "group_name" field is being filled in even if the mouse is not bred in house. We don't want to map that info anymore since the functionality has changed. Now, it'll properly distinguish whether a mouse was bred in house (if some breeding info exists), or unknown (if None). 
 
This PR: 
- upgrades aind-data-schema-models pinned version
- Switches Organization.OTHER to Organization.UNKNOWN
- Sets BreedingInfo.breeding_group to None (Labtracks group_name has different info). Note this means the BreedingInfo model is now invalid.

Note:
Removed breeding group since that was the request. Alternatively, we could keep the group name from Labtracks in BreedingInfo.breeding_group but change the source logic to specifically check for maternal or paternal ids? @dbirman Let me know if that would work? 