### PR TITLE
feat: adds endpoint to post instruments

### DIFF
--- a/aind-metadata-service-server/pyproject.toml
+++ b/aind-metadata-service-server/pyproject.toml
@@ -29,6 +29,7 @@ dependencies = [
     'pydantic>=2.0',
     'pydantic-settings>=2.0',
     'fastapi[standard]>=0.114.0',
+    'aind-data-access-api==1.9.0'
 ]
 
 [project.optional-dependencies]
@@ -107,4 +108,5 @@ env = [
     "AIND_METADATA_SERVICE_SESSION_JSON_HOST=http://example.com/session_json",
     "AIND_METADATA_SERVICE_SHAREPOINT_HOST=http://example.com/sharepoint",
     "AIND_METADATA_SERVICE_AIND_DATA_SCHEMA_V1_HOST=http://example.com/v1",
+    "AIND_METADATA_SERVICE_DOCDB_API_HOST=http://example.com/docdb",
 ]

--- a/aind-metadata-service-server/src/aind_metadata_service_server/configs.py
+++ b/aind-metadata-service-server/src/aind_metadata_service_server/configs.py
@@ -34,6 +34,9 @@ class Settings(BaseSettings):
     aind_data_schema_v1_host: HttpUrl = Field(
         ..., description="Host address for v1 service"
     )
+    docdb_api_host: str = Field(
+        ..., description="Host address for data access api"
+    )
 
 
 def get_settings():

--- a/aind-metadata-service-server/src/aind_metadata_service_server/routes/rig_and_instrument.py
+++ b/aind-metadata-service-server/src/aind_metadata_service_server/routes/rig_and_instrument.py
@@ -1,10 +1,18 @@
 """Module to handle rig and instrument endpoints"""
 
+import hashlib
+from asyncio import gather, to_thread
+from uuid import UUID
+
+from aind_data_access_api.document_db import Client as DocDBClient
 from aind_slims_service_async_client import DefaultApi
-from fastapi import APIRouter, Depends, HTTPException, Path, Query
+from fastapi import APIRouter, Body, Depends, HTTPException, Path, Query
 from fastapi.responses import JSONResponse
 
-from aind_metadata_service_server.sessions import get_slims_api_instance
+from aind_metadata_service_server.sessions import (
+    get_instruments_client,
+    get_slims_api_instance,
+)
 
 router = APIRouter()
 
@@ -55,15 +63,35 @@ async def get_instrument(
     ),
     partial_match: bool = Query(False, alias="partial_match"),
     slims_api_instance: DefaultApi = Depends(get_slims_api_instance),
+    docdb_client: DocDBClient = Depends(get_instruments_client),
 ):
     """
     ## Instrument
     Return an Instrument.
     """
 
-    instruments = await slims_api_instance.get_aind_instrument(
-        input_id=instrument_id, partial_match=partial_match
+    if not partial_match:
+        filter_query = {"instrument_id": {"$regex": instrument_id}}
+    else:
+        filter_query = {"instrument_id": instrument_id}
+    slims_instruments, docdb_instruments = await gather(
+        slims_api_instance.get_aind_instrument(
+            input_id=instrument_id, partial_match=partial_match
+        ),
+        to_thread(
+            docdb_client.retrieve_docdb_records,
+            filter_query=filter_query,
+            projection={"_id": 0},
+        ),
     )
+    instruments = []
+    seen_ids = set()
+    for instrument in docdb_instruments:
+        seen_ids = instrument["instrument_id"]
+        instruments.append(instrument)
+    for instrument in slims_instruments:
+        if instrument.get("instrument_id") not in seen_ids:
+            instruments.append(instrument)
     if len(instruments) == 0:
         raise HTTPException(status_code=404, detail="Not found")
     else:
@@ -72,3 +100,28 @@ async def get_instrument(
             content=instruments,
             headers={"X-Error-Message": "Models have not been validated."},
         )
+
+
+@router.post("/api/v2/instrument")
+def post_instrument(
+    data: dict = Body(...),
+    docdb_client: DocDBClient = Depends(get_instruments_client),
+):
+    """
+    ## Instrument
+    Save an instrument to a database.
+    """
+    if (
+        data.get("instrument_id") is None
+        or not isinstance(data["instrument_id"], str)
+        or data["instrument_id"].strip() == ""
+    ):
+        return JSONResponse(
+            status_code=406, content={"message": "Missing instrument_id."}
+        )
+    else:
+        encoded_string = data["instrument_id"].encode("utf-8")
+        md5_hash = hashlib.md5(encoded_string).hexdigest()
+        data["_id"] = str(UUID(md5_hash))
+        response = docdb_client.insert_one_docdb_record(data)
+        return response.json()

--- a/aind-metadata-service-server/src/aind_metadata_service_server/sessions.py
+++ b/aind-metadata-service-server/src/aind_metadata_service_server/sessions.py
@@ -8,6 +8,7 @@ import aind_sharepoint_service_async_client
 import aind_slims_service_async_client
 import aind_smartsheet_service_async_client
 import aind_tars_service_async_client
+from aind_data_access_api.document_db import Client as DocDBClient
 from httpx import AsyncClient
 
 from aind_metadata_service_server.configs import get_settings
@@ -128,3 +129,14 @@ async def get_slims_api_instance() -> (
     ) as api_client:
         api_instance = aind_slims_service_async_client.DefaultApi(api_client)
         yield api_instance
+
+
+def get_instruments_client() -> DocDBClient:
+    """
+    Returns a client to read/write instruments.
+    """
+    return DocDBClient(
+        host=settings.docdb_api_host,
+        database="metadata_files",
+        collection="instruments",
+    )

--- a/aind-metadata-service-server/tests/test_configs.py
+++ b/aind-metadata-service-server/tests/test_configs.py
@@ -31,6 +31,7 @@ class TestSettings(unittest.TestCase):
             "AIND_METADATA_SERVICE_AIND_DATA_SCHEMA_V1_HOST": (
                 "http://example.com/v1"
             ),
+            "AIND_METADATA_SERVICE_DOCDB_API_HOST": ("example.com/docdb"),
         },
         clear=True,
     )
@@ -45,6 +46,7 @@ class TestSettings(unittest.TestCase):
             tars_host="http://example.com/tars",
             sharepoint_host="http://example.com/sharepoint",
             session_json_host="http://example.com/session_json",
+            docdb_api_host="example.com/docdb",
         )
         self.assertEqual(expected_settings, settings)
 

--- a/aind-metadata-service-server/tests/test_routes/test_rig_and_instrument.py
+++ b/aind-metadata-service-server/tests/test_routes/test_rig_and_instrument.py
@@ -1,11 +1,13 @@
 """Test rig and instrument routes"""
 
 import json
+from copy import deepcopy
 from pathlib import Path
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from fastapi.testclient import TestClient
+from requests import Response
 
 TEST_DIR = Path(__file__).parent / ".."
 TEST_RIG_JSON = TEST_DIR / "resources" / "slims" / "rig_example.json"
@@ -45,14 +47,19 @@ class TestRoute:
         "aind_slims_service_async_client.DefaultApi.get_aind_instrument",
         new_callable=AsyncMock,
     )
+    @patch("aind_metadata_service_server.routes.rig_and_instrument.to_thread")
     def test_get_instrument(
         self,
+        mock_to_thread: AsyncMock,
         mock_slims_api_get: AsyncMock,
         client: TestClient,
     ):
         """Tests a good response"""
         with open(TEST_INSTRUMENT_JSON) as f:
             instrument_data = json.load(f)
+        mocked_docdb_record = deepcopy(instrument_data)
+        mocked_docdb_record["instrument_id"] = "440_SmartSPIM1_20240328"
+        mock_to_thread.return_value = [mocked_docdb_record]
         mock_slims_api_get.return_value = [instrument_data]
         response = client.get(
             "/api/v2/instrument/440_SmartSPIM1_20240327?partial_match=True"
@@ -91,12 +98,15 @@ class TestRoute:
         "aind_slims_service_async_client.DefaultApi.get_aind_instrument",
         new_callable=AsyncMock,
     )
+    @patch("aind_metadata_service_server.routes.rig_and_instrument.to_thread")
     def test_get_instrument_not_found(
         self,
+        mock_to_thread: AsyncMock,
         mock_slims_api_get: AsyncMock,
         client: TestClient,
     ):
         """Tests 404 response when instrument is not found"""
+        mock_to_thread.return_value = []
         mock_slims_api_get.return_value = []
 
         response = client.get("/api/v2/instrument/nonexistent_instrument")
@@ -106,6 +116,49 @@ class TestRoute:
         )
         assert 404 == response.status_code
         assert response.json()["detail"] == "Not found"
+
+    @patch(
+        "aind_metadata_service_server.routes.rig_and_instrument.DocDBClient"
+        ".insert_one_docdb_record"
+    )
+    def test_post_instrument_success(
+        self,
+        mock_docdb_client_insert: MagicMock,
+        client: TestClient,
+    ):
+        """Tests success post response for an instrument"""
+        mock_response = Response()
+        mock_response.status_code = 200
+        mock_response._content = json.dumps({"message": "success"}).encode(
+            "utf-8"
+        )
+        mock_docdb_client_insert.return_value = mock_response
+        body = {"instrument_id": "abc"}
+        response = client.post("/api/v2/instrument", json=body)
+        mock_docdb_client_insert.assert_called_once_with(
+            {
+                "instrument_id": "abc",
+                "_id": "90015098-3cd2-4fb0-d696-3f7d28e17f72",
+            },
+        )
+        assert 200 == response.status_code
+        assert response.json() == {"message": "success"}
+
+    @patch(
+        "aind_metadata_service_server.routes.rig_and_instrument.DocDBClient"
+        ".insert_one_docdb_record"
+    )
+    def test_post_instrument_failure(
+        self,
+        mock_docdb_client_insert: MagicMock,
+        client: TestClient,
+    ):
+        """Tests success post response for an instrument"""
+        body = {"field1": "abc"}
+        response = client.post("/api/v2/instrument", json=body)
+        mock_docdb_client_insert.assert_not_called()
+        assert 406 == response.status_code
+        assert response.json() == {"message": "Missing instrument_id."}
 
 
 if __name__ == "__main__":

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -16,6 +16,9 @@ services:
       - redis
       - aind_metadata_service_v1
     env_file: "env/webapp.env"
+    volumes:
+      - $HOME/.aws/credentials:/root/.aws/credentials:ro
+      - $HOME/.aws/config:/root/.aws/config:ro
   labtracks:
     image: "ghcr.io/allenneuraldynamics/aind-labtracks-service-server:0.3.0"
     env_file: "env/labtracks.env"


### PR DESCRIPTION
- Adds an endpoint for users to save instrument.json to DocDB
- Fetches from DocDB and SLIMS when requesting instrument files and removes duplicate entries
- Intended as a stopgap solution until Dataverse is operational