### PR TITLE
feat: adds upsert option to post endpoint

### DIFF
--- a/aind-metadata-service-server/src/aind_metadata_service_server/routes/rig_and_instrument.py
+++ b/aind-metadata-service-server/src/aind_metadata_service_server/routes/rig_and_instrument.py
@@ -1,6 +1,7 @@
 """Module to handle rig and instrument endpoints"""
 
 import hashlib
+import logging
 from asyncio import gather, to_thread
 from uuid import UUID
 
@@ -105,7 +106,7 @@ async def get_instrument(
 
 @router.post("/api/v2/instrument")
 def post_instrument(
-    upsert: bool = Query(default=False),
+    replace: bool = Query(default=False),
     data: dict = Body(...),
     docdb_client: DocDBClient = Depends(get_instruments_client),
 ):
@@ -137,10 +138,12 @@ def post_instrument(
         md5_hash = hashlib.md5(encoded_string).hexdigest()
         data["_id"] = str(UUID(md5_hash))
         try:
-            if not upsert:
+            if not replace:
                 response = docdb_client.insert_one_docdb_record(data)
             else:
-                response = docdb_client.upsert_one_docdb_record(data)
+                response1 = docdb_client.delete_one_record(data["_id"])
+                logging.info(response1.json())
+                response = docdb_client.insert_one_docdb_record(data)
             return response.json()
         except HTTPError as e:
             if "duplicate key error" in e.response.text:

--- a/aind-metadata-service-server/tests/test_routes/test_rig_and_instrument.py
+++ b/aind-metadata-service-server/tests/test_routes/test_rig_and_instrument.py
@@ -147,25 +147,34 @@ class TestRoute:
 
     @patch(
         "aind_metadata_service_server.routes.rig_and_instrument.DocDBClient"
-        ".upsert_one_docdb_record"
+        ".delete_one_record"
     )
-    def test_post_upsert_instrument_success(
+    @patch(
+        "aind_metadata_service_server.routes.rig_and_instrument.DocDBClient"
+        ".insert_one_docdb_record"
+    )
+    def test_post_replace_instrument_success(
         self,
-        mock_docdb_client_upsert: MagicMock,
+        mock_docdb_client_insert_one: MagicMock,
+        mock_docdb_client_delete_one: MagicMock,
         client: TestClient,
     ):
-        """Tests success post response for an instrument with upsert True"""
+        """Tests success post response for an instrument with replace True"""
         mock_response = Response()
         mock_response.status_code = 200
         mock_response._content = json.dumps({"message": "success"}).encode(
             "utf-8"
         )
-        mock_docdb_client_upsert.return_value = mock_response
+        mock_docdb_client_delete_one.return_value = mock_response
+        mock_docdb_client_insert_one.return_value = mock_response
         body = {"instrument_id": "abc", "modification_date": "2025-10-10"}
         response = client.post(
-            "/api/v2/instrument", json=body, params={"upsert": True}
+            "/api/v2/instrument", json=body, params={"replace": True}
         )
-        mock_docdb_client_upsert.assert_called_once_with(
+        mock_docdb_client_delete_one.assert_called_once_with(
+            "e9851dd4-297a-4fc6-91ec-5665823326a5"
+        )
+        mock_docdb_client_insert_one.assert_called_once_with(
             {
                 "instrument_id": "abc",
                 "modification_date": "2025-10-10",


### PR DESCRIPTION
Closes #604 

- Allows user to set an replace option to True to allow overwriting an existing record

```python
import requests

url = "http://localhost:5000/api/v2/instrument"
instrument_id = "TEST4"
instrument = {"instrument_id": instrument_id, "modification_date": "2025-11-20", "fieldA": "1"}
response = requests.post(url, json=instrument)
instrument_update = {"instrument_id": instrument_id, "modification_date": "2025-11-20", "fieldB": "2"}
# Raises an error
response = requests.post(url, json=instrument_update)
print(response.json())
# {'message': 'Record for instrument_id and modification_date already exists!'}
# Merges the documents
response = requests.post(url, json=instrument_update, params={"replace": True})
print(response.json())
# {'acknowledged': True, 'modifiedCount': 1, 'upsertedId': None, 'upsertedCount': 0, 'matchedCount': 1}
response = requests.get(f"{url}/{instrument_id}", json=instrument_update, params={"upsert": True})
print(response.json())
# [{'instrument_id': 'TEST4', 'modification_date': '2025-11-20', 'fieldA': '1', 'fieldB': '2'}]

```