### PR TITLE
fix: error for non integer subject

### DIFF
--- a/aind-metadata-service-server/src/aind_metadata_service_server/routes/subject.py
+++ b/aind-metadata-service-server/src/aind_metadata_service_server/routes/subject.py
@@ -36,9 +36,12 @@ async def get_subject(
     if not subject_id.isdigit():
         raise HTTPException(
             status_code=406,
-            detail=f"Subject ID {subject_id} is not valid. Please specify a numeric "
+            detail=(
+                f"Subject ID {subject_id} is not valid."
+                " Please specify a numeric subject ID."
+            ),
         )
-    
+
     labtracks_response = await labtracks_api_instance.get_subject(
         subject_id, _request_timeout=10
     )
@@ -90,10 +93,13 @@ async def get_labtracks_subject(
     """
     if not subject_id.isdigit():
         raise HTTPException(
-            status_code=406, 
-            detail=f"Subject ID {subject_id} is not a valid subject."
+            status_code=406,
+            detail=(
+                f"Subject ID {subject_id} is not valid."
+                " Please specify a numeric subject ID."
+            ),
         )
-    
+
     labtracks_response = await labtracks_api_instance.get_subject(
         subject_id, _request_timeout=10
     )

--- a/aind-metadata-service-server/tests/test_routes/test_subject.py
+++ b/aind-metadata-service-server/tests/test_routes/test_subject.py
@@ -119,7 +119,10 @@ class TestRoute:
         """Tests handling of invalid subject ID"""
         response = client.get("api/v2/subject/abcd")
         expected_response = {
-            "detail": "Subject ID abcd is not a valid subject."
+            "detail": (
+                "Subject ID abcd is not valid."
+                " Please specify a numeric subject ID."
+            )
         }
         assert 406 == response.status_code
         assert expected_response == response.json()
@@ -196,10 +199,14 @@ class TestRoute:
         """Tests handling of invalid subject ID for LabTracks"""
         response = client.get("api/v2/labtracks/subject?subject_id=abcd")
         expected_response = {
-            "detail": "Subject ID abcd is not a valid subject."
+            "detail": (
+                "Subject ID abcd is not valid."
+                " Please specify a numeric subject ID."
+            )
         }
         assert 406 == response.status_code
         assert expected_response == response.json()
+
 
 if __name__ == "__main__":
     pytest.main([__file__])


### PR DESCRIPTION
closes #549

Labtracks cannot take non-integer values for subject_id (the sql query errors out). This PR adds checks in api/v2/subject and api/v2/labtracks/subject endpoints for numeric subject_id. If not a digit, throws a 406 error with message 

Considerations:
- Considered handling this in the labtracks service itself but wanted to keep that simple