### PR TITLE
Feat: Splits V2 Funding to Funding and Investigators endpoints

### DIFF
--- a/aind-metadata-service-server/src/aind_metadata_service_server/models.py
+++ b/aind-metadata-service-server/src/aind_metadata_service_server/models.py
@@ -6,9 +6,7 @@ import xml.etree.ElementTree as ET
 from datetime import datetime
 from typing import Any, List, Literal, Optional
 
-from aind_data_schema.components.identifiers import Person
 from aind_data_schema.components.injection_procedures import ViralMaterial
-from aind_data_schema.core.data_description import Funding
 from aind_slims_service_async_client import (
     EcephysStreamModule,
     SlimsEcephysData,
@@ -64,13 +62,6 @@ class IntendedMeasurementInformation(BaseModel):
     intended_measurement_G: Optional[str] = None
     intended_measurement_B: Optional[str] = None
     intended_measurement_Iso: Optional[str] = None
-
-
-class FundingInformation(Funding):
-    """Funding information that will be returned to the user that requests
-    information from the Funding SmartSheet"""
-
-    investigators: Optional[List[Person]] = Field(default=None)
 
 
 class SpimData(SlimsSpimData):

--- a/aind-metadata-service-server/tests/test_mappers/test_funding.py
+++ b/aind-metadata-service-server/tests/test_mappers/test_funding.py
@@ -7,7 +7,7 @@ from aind_data_schema_models.organizations import Organization
 from aind_smartsheet_service_async_client.models import FundingModel
 
 from aind_metadata_service_server.mappers.funding import FundingMapper
-from aind_metadata_service_server.models import FundingInformation
+from aind_data_schema.core.data_description import Funding
 
 
 class TestFundingMapper(unittest.TestCase):
@@ -99,13 +99,13 @@ class TestFundingMapper(unittest.TestCase):
             FundingMapper.split_name(project_c),
         )
 
-    def test_mapping_success(self):
+    def test_mapping_funding_success(self):
         """Tests successful mapping of funding data"""
         discovery_funding_rows = self.funding_sheet[3:5]
         mapper = FundingMapper(smartsheet_funding=discovery_funding_rows)
         funding_information = mapper.get_funding_list()
         expected_funding = [
-            FundingInformation(
+            Funding(
                 funder=Organization.AI,
                 grant_number=None,
                 fundee=[
@@ -115,9 +115,8 @@ class TestFundingMapper(unittest.TestCase):
                     Person(name="Person Seven"),
                     Person(name="Person Eight"),
                 ],
-                investigators=None,
             ),
-            FundingInformation(
+            Funding(
                 funder=Organization.NINDS,
                 grant_number="1RF1NS131984",
                 fundee=[
@@ -125,14 +124,24 @@ class TestFundingMapper(unittest.TestCase):
                     Person(name="Person Six"),
                     Person(name="Person Eight"),
                 ],
-                investigators=[
-                    Person(name="Person Six"),
-                    Person(name="Person Eight"),
-                ],
             ),
         ]
         self.assertEqual(len(funding_information), 2)
         self.assertEqual(funding_information, expected_funding)
+
+    def test_mapping_investigators_success(self):
+        """Tests successful mapping of investigators from funding data"""
+        discovery_funding_rows = self.funding_sheet[3:5]
+        mapper = FundingMapper(smartsheet_funding=discovery_funding_rows)
+        investigators_information = mapper.get_investigators_list()
+        expected_investigators = [
+            Person(name="Person Six"),
+            Person(name="Person Eight"),
+        ]
+        self.assertEqual(
+            sorted(investigators_information, key=lambda x: x.name),
+            sorted(expected_investigators, key=lambda x: x.name),
+        )
 
     def test_mapping_empty_list(self):
         """Tests mapping with empty funding data list"""
@@ -164,7 +173,7 @@ class TestFundingMapper(unittest.TestCase):
         mapper = FundingMapper(smartsheet_funding=smartsheet_funding)
         funding_information = mapper.get_funding_list()
 
-        expected_model = FundingInformation.model_construct(
+        expected_model = Funding.model_construct(
             funder="Some Institute",
             grant_number=None,
             fundee=[
@@ -172,7 +181,6 @@ class TestFundingMapper(unittest.TestCase):
                 Person(name="Person Two"),
                 Person(name="Person Three"),
             ],
-            investigators=None,
         )
 
         self.assertEqual(1, len(funding_information))

--- a/aind-metadata-service-server/tests/test_routes/test_funding.py
+++ b/aind-metadata-service-server/tests/test_routes/test_funding.py
@@ -112,6 +112,106 @@ class TestRoute:
         "aind_smartsheet_service_async_client.DefaultApi.get_funding",
         new_callable=AsyncMock,
     )
+    def test_get_investigators(
+        self,
+        mock_get_funding: AsyncMock,
+        client: TestClient,
+    ):
+        """
+        Tests successful investigators retrieval with subproject specified
+        """
+        discovery_project = (
+            "Discovery-Neuromodulator circuit dynamics during foraging"
+        )
+        sub1 = (
+            "Subproject 1 Electrophysiological Recordings from NM Neurons"
+            " During Behavior"
+        )
+        mock_get_funding.return_value = [
+            FundingModel(
+                project_name=discovery_project,
+                subproject=sub1,
+                project_code="122-01-001-10",
+                funding_institution="Allen Institute",
+                fundees__pi=(
+                    "Person Four, Person Five, Person Six, Person Seven,"
+                    " Person Eight"
+                ),
+            ),
+            FundingModel(
+                project_name=discovery_project,
+                subproject=sub1,
+                project_code="122-01-012-20",
+                funding_institution="NINDS",
+                grant_number="1RF1NS131984",
+                fundees__pi="Person Five, Person Six, Person Eight",
+                investigators="Person Six, Person Eight",
+            ),
+        ]
+        response = client.get(
+            "/api/v2/investigators/"
+            "Discovery-Neuromodulator circuit dynamics during foraging -"
+            " Subproject 1 Electrophysiological Recordings from NM Neurons"
+            " During Behavior"
+        )
+        assert 200 == response.status_code
+        assert 1 == len(mock_get_funding.mock_calls)
+
+    @patch(
+        "aind_smartsheet_service_async_client.DefaultApi.get_funding",
+        new_callable=AsyncMock,
+    )
+    def test_get_investigators_without_subproject(
+        self,
+        mock_get_funding: AsyncMock,
+        client: TestClient,
+    ):
+        """Tests investigators retrieval without subproject parameter"""
+        discovery_project = (
+            "Discovery-Neuromodulator circuit dynamics during foraging"
+        )
+        sub1 = (
+            "Subproject 1 Electrophysiological Recordings from NM Neurons"
+            " During Behavior"
+        )
+        sub2 = "Subproject 2 Molecular Anatomy Cell Types"
+
+        mock_get_funding.return_value = [
+            FundingModel(
+                project_name=discovery_project,
+                subproject=sub1,
+                project_code="122-01-001-10",
+                funding_institution="Allen Institute",
+                fundees__pi=(
+                    "Person Four, Person Five, Person Six, Person Seven,"
+                    " Person Eight"
+                ),
+            ),
+            FundingModel(
+                project_name=discovery_project,
+                subproject=sub2,
+                project_code="122-01-001-10",
+                funding_institution="Allen Institute",
+                grant_number=None,
+                fundees__pi=(
+                    "Person Four, Person Five, Person Six, Person Seven,"
+                    " Person Eight"
+                ),
+                investigators="Person Seven",
+            ),
+        ]
+        response = client.get(
+            "/api/v2/investigators/Discovery-Neuromodulator circuit dynamics "
+            "during foraging"
+        )
+
+        assert 406 == response.status_code
+        assert 1 == len(mock_get_funding.mock_calls)
+
+    @patch(
+        "aind_smartsheet_service_async_client.DefaultApi.get_funding",
+        new_callable=AsyncMock,
+    )
     def test_get_project_names(
         self,
         mock_get_funding: AsyncMock,
@@ -192,6 +292,21 @@ class TestRoute:
         """Tests 404 response when no funding information is found"""
         mock_get_funding.return_value = []
         response = client.get("/api/v2/funding/Nonexistent Project Name")
+        assert 404 == response.status_code
+        assert 1 == len(mock_get_funding.mock_calls)
+
+    @patch(
+        "aind_smartsheet_service_async_client.DefaultApi.get_funding",
+        new_callable=AsyncMock,
+    )
+    def test_get_investigators_not_found(
+        self,
+        mock_get_funding: AsyncMock,
+        client: TestClient,
+    ):
+        """Tests 404 response when no investigators information is found"""
+        mock_get_funding.return_value = []
+        response = client.get("/api/v2/investigators/Nonexistent Project Name")
         assert 404 == response.status_code
         assert 1 == len(mock_get_funding.mock_calls)
 


### PR DESCRIPTION
Closes #582 

This PR: 
- The V2 funding endpoint now returns data-schema compliant Funding model (instead of FundingInformation)
- Adds a new endpoint (api/v2/investigators) that returns a list of Person models given a project name. 
- If given project has multiple subprojects, the investigators endpoint errors and ask user to enter with subproject (same behavior as api/v2/funding)
 