### PR TITLE
Fix: Updates mappings for coordinate system to drop SI dimension

### DIFF
--- a/aind-metadata-service-server/src/aind_metadata_service_server/mappers/nsb2023.py
+++ b/aind-metadata-service-server/src/aind_metadata_service_server/mappers/nsb2023.py
@@ -259,6 +259,20 @@ class IntendedMeasurementandCoords:
     intended_measurement_Iso: Optional[str] = None
 
 
+# Define BREGMA_ARD coordinate system (3 axes: AP, ML, Depth)
+# NSB doesn't provide SI dimension data, so we use ARD instead of ARID
+BREGMA_ARD = CoordinateSystem(
+    name="BREGMA_ARD",
+    origin=Origin.BREGMA,
+    axis_unit=SizeUnit.MM,
+    axes=[
+        Axis(name=AxisName.AP, direction=Direction.PA),
+        Axis(name=AxisName.ML, direction=Direction.LR),
+        Axis(name=AxisName.DEPTH, direction=Direction.UD),
+    ],
+)
+
+
 class MappedNSBList:
     """Mapped Fields in SharePoint list."""
 
@@ -2512,7 +2526,7 @@ class MappedNSBList:
                 ],
             )
             coordinate_system = (
-                CoordinateSystemLibrary.BREGMA_ARID
+                BREGMA_ARD
                 if coordinate_depth
                 else CoordinateSystemLibrary.BREGMA_ARI
             )
@@ -2562,7 +2576,7 @@ class MappedNSBList:
                 ],
             )
             coordinate_system = (
-                CoordinateSystemLibrary.BREGMA_ARID
+                BREGMA_ARD
                 if coordinate_depth
                 else CoordinateSystemLibrary.BREGMA_ARI
             )
@@ -2612,7 +2626,7 @@ class MappedNSBList:
                 ],
             )
             coordinate_system = (
-                CoordinateSystemLibrary.BREGMA_ARID
+                BREGMA_ARD
                 if coordinate_depth
                 else CoordinateSystemLibrary.BREGMA_ARI
             )
@@ -2661,7 +2675,7 @@ class MappedNSBList:
                 ],
             )
             coordinate_system = (
-                CoordinateSystemLibrary.BREGMA_ARID
+                BREGMA_ARD
                 if coordinate_depth
                 else CoordinateSystemLibrary.BREGMA_ARI
             )
@@ -2710,7 +2724,7 @@ class MappedNSBList:
                 ],
             )
             coordinate_system = (
-                CoordinateSystemLibrary.BREGMA_ARID
+                BREGMA_ARD
                 if coordinate_depth
                 else CoordinateSystemLibrary.BREGMA_ARI
             )
@@ -2759,7 +2773,7 @@ class MappedNSBList:
                 ],
             )
             coordinate_system = (
-                CoordinateSystemLibrary.BREGMA_ARID
+                BREGMA_ARD
                 if coordinate_depth
                 else CoordinateSystemLibrary.BREGMA_ARI
             )
@@ -2923,13 +2937,36 @@ class MappedNSBList:
         """Assigns fiber name for intended measurement by coordinate info"""
 
         intended_measurments = []
+
+        # Filter to measurements with at least one measurement value
+        measurements_with_values = [
+            m for m in sp_measurement_data
+            if (
+                m.intended_measurement_R is not None
+                or m.intended_measurement_G is not None
+                or m.intended_measurement_B is not None
+                or m.intended_measurement_Iso is not None
+            )
+        ]
+        measurements_with_coords = [
+            m for m in measurements_with_values
+            if m.coordinate_ap is not None and m.coordinate_ml is not None
+        ]
+        measurements_without_coords = [
+            m for m in measurements_with_values
+            if m.coordinate_ap is None or m.coordinate_ml is None
+        ]
+
+        # Sort measurements with coordinates by AP descending, ML ascending
         sorted_data = sorted(
-            sp_measurement_data,
+            measurements_with_coords,
             key=lambda measurement: (
                 -float(measurement.coordinate_ap),
                 float(measurement.coordinate_ml),
             ),
         )
+        
+        # Add sorted measurements with fiber names
         for index, data in enumerate(sorted_data):
             intended_measurments.append(
                 IntendedMeasurementInformation(
@@ -2940,6 +2977,19 @@ class MappedNSBList:
                     intended_measurement_Iso=data.intended_measurement_Iso,
                 )
             )
+        
+        # Add measurements without coordinates (no fiber name)
+        for data in measurements_without_coords:
+            intended_measurments.append(
+                IntendedMeasurementInformation(
+                    fiber_name=None,
+                    intended_measurement_R=data.intended_measurement_R,
+                    intended_measurement_B=data.intended_measurement_B,
+                    intended_measurement_G=data.intended_measurement_G,
+                    intended_measurement_Iso=data.intended_measurement_Iso,
+                )
+            )
+        
         return intended_measurments
 
     def get_intended_measurements(
@@ -2984,16 +3034,29 @@ class MappedNSBList:
                     )
                 else:
                     # skip fiber name assignment if no During info
-                    all_intended_measurements.append(
-                        IntendedMeasurementInformation(
-                            intended_measurement_R=burr.intended_measurement_r,
-                            intended_measurement_B=burr.intended_measurement_b,
-                            intended_measurement_G=burr.intended_measurement_g,
-                            intended_measurement_Iso=(
-                                burr.intended_measurement_iso
-                            ),
+                    # only add if at least one measurement value exists
+                    if (
+                        burr.intended_measurement_r is not None
+                        or burr.intended_measurement_g is not None
+                        or burr.intended_measurement_b is not None
+                        or burr.intended_measurement_iso is not None
+                    ):
+                        all_intended_measurements.append(
+                            IntendedMeasurementInformation(
+                                intended_measurement_R=(
+                                    burr.intended_measurement_r
+                                ),
+                                intended_measurement_B=(
+                                    burr.intended_measurement_b
+                                ),
+                                intended_measurement_G=(
+                                    burr.intended_measurement_g
+                                ),
+                                intended_measurement_Iso=(
+                                    burr.intended_measurement_iso
+                                ),
+                            )
                         )
-                    )
         all_intended_measurements.extend(
             self._get_intended_measurements(initial_measurements)
         )
@@ -3091,10 +3154,10 @@ class MappedNSBList:
                 ],
             )
 
-        # Prioritize ARID over ARI, and LAMBDA over BREGMA if all are lambda
+        # Prioritize ARD over ARI, and LAMBDA over BREGMA if all are lambda
         names = [s.name for s in systems if s]
-        if any(n.endswith("ARID") for n in names):
-            return CoordinateSystemLibrary.BREGMA_ARID
+        if any(n.endswith("ARD") for n in names):
+            return BREGMA_ARD
         elif any(n.endswith("ARI") for n in names):
             if all(n.startswith("LAMBDA") for n in names):
                 return CoordinateSystem(
@@ -3140,12 +3203,12 @@ class MappedNSBList:
         # If all coordinates are None, return empty translation
         if ap is None and ml is None and depth is None:
             angle_val = float(angle) if angle is not None else 0.0
-            is_arid = (
+            is_ard = (
                 surgery_coordinate_system is not None
-                and surgery_coordinate_system.name.endswith("ARID")
+                and surgery_coordinate_system.name.endswith("ARD")
             )
             rotation = Rotation(
-                angles=[angle_val, 0, 0, 0] if is_arid else [angle_val, 0, 0],
+                angles=[angle_val, 0, 0] if is_ard else [angle_val, 0, 0],
                 angles_unit=AngleUnit.DEG,
             )
             return [[Translation.model_construct(translation=[]), rotation]]
@@ -3154,22 +3217,22 @@ class MappedNSBList:
         ap_val = float(ap) if ap is not None else None
         ml_val = float(ml) if ml is not None else None
         angle_val = float(angle) if angle is not None else 0.0
-        is_arid = (
+        is_ard = (
             surgery_coordinate_system is not None
-            and surgery_coordinate_system.name.endswith("ARID")
+            and surgery_coordinate_system.name.endswith("ARD")
         )
 
         transforms = []
         if depth is None:
             translation = Translation.model_construct(
                 translation=(
-                    [ap_val, ml_val, 0, None]
-                    if is_arid
+                    [ap_val, ml_val, None]
+                    if is_ard
                     else [ap_val, ml_val, 0]
                 )
             )
             rotation = Rotation(
-                angles=[angle_val, 0, 0, 0] if is_arid else [angle_val, 0, 0],
+                angles=[angle_val, 0, 0] if is_ard else [angle_val, 0, 0],
                 angles_unit=AngleUnit.DEG,
             )
             transforms.append([translation, rotation])
@@ -3178,14 +3241,14 @@ class MappedNSBList:
                 d_val = float(d) if d is not None else None
                 translation = Translation.model_construct(
                     translation=(
-                        [ap_val, ml_val, 0, d_val]
-                        if is_arid
+                        [ap_val, ml_val, d_val]
+                        if is_ard
                         else [ap_val, ml_val, 0]
                     )
                 )
                 rotation = Rotation(
                     angles=(
-                        [angle_val, 0, 0, 0] if is_arid else [angle_val, 0, 0]
+                        [angle_val, 0, 0] if is_ard else [angle_val, 0, 0]
                     ),
                     angles_unit=AngleUnit.DEG,
                 )
@@ -3634,7 +3697,7 @@ class MappedNSBList:
         if other_procedures:
             self.assign_fiber_probe_names(other_procedures)
             measured_coordinates = self.map_measured_coordinates(
-                self.aind_breg2_lamb, CoordinateSystemLibrary.BREGMA_ARID
+                self.aind_breg2_lamb, BREGMA_ARD
             )
             other_surgery = Surgery.model_construct(
                 start_date=None,

--- a/aind-metadata-service-server/src/aind_metadata_service_server/mappers/nsb2023.py
+++ b/aind-metadata-service-server/src/aind_metadata_service_server/mappers/nsb2023.py
@@ -2937,36 +2937,13 @@ class MappedNSBList:
         """Assigns fiber name for intended measurement by coordinate info"""
 
         intended_measurments = []
-
-        # Filter to measurements with at least one measurement value
-        measurements_with_values = [
-            m for m in sp_measurement_data
-            if (
-                m.intended_measurement_R is not None
-                or m.intended_measurement_G is not None
-                or m.intended_measurement_B is not None
-                or m.intended_measurement_Iso is not None
-            )
-        ]
-        measurements_with_coords = [
-            m for m in measurements_with_values
-            if m.coordinate_ap is not None and m.coordinate_ml is not None
-        ]
-        measurements_without_coords = [
-            m for m in measurements_with_values
-            if m.coordinate_ap is None or m.coordinate_ml is None
-        ]
-
-        # Sort measurements with coordinates by AP descending, ML ascending
         sorted_data = sorted(
-            measurements_with_coords,
+            sp_measurement_data,
             key=lambda measurement: (
                 -float(measurement.coordinate_ap),
                 float(measurement.coordinate_ml),
             ),
         )
-        
-        # Add sorted measurements with fiber names
         for index, data in enumerate(sorted_data):
             intended_measurments.append(
                 IntendedMeasurementInformation(
@@ -2977,19 +2954,6 @@ class MappedNSBList:
                     intended_measurement_Iso=data.intended_measurement_Iso,
                 )
             )
-        
-        # Add measurements without coordinates (no fiber name)
-        for data in measurements_without_coords:
-            intended_measurments.append(
-                IntendedMeasurementInformation(
-                    fiber_name=None,
-                    intended_measurement_R=data.intended_measurement_R,
-                    intended_measurement_B=data.intended_measurement_B,
-                    intended_measurement_G=data.intended_measurement_G,
-                    intended_measurement_Iso=data.intended_measurement_Iso,
-                )
-            )
-        
         return intended_measurments
 
     def get_intended_measurements(
@@ -3034,29 +2998,16 @@ class MappedNSBList:
                     )
                 else:
                     # skip fiber name assignment if no During info
-                    # only add if at least one measurement value exists
-                    if (
-                        burr.intended_measurement_r is not None
-                        or burr.intended_measurement_g is not None
-                        or burr.intended_measurement_b is not None
-                        or burr.intended_measurement_iso is not None
-                    ):
-                        all_intended_measurements.append(
-                            IntendedMeasurementInformation(
-                                intended_measurement_R=(
-                                    burr.intended_measurement_r
-                                ),
-                                intended_measurement_B=(
-                                    burr.intended_measurement_b
-                                ),
-                                intended_measurement_G=(
-                                    burr.intended_measurement_g
-                                ),
-                                intended_measurement_Iso=(
-                                    burr.intended_measurement_iso
-                                ),
-                            )
+                    all_intended_measurements.append(
+                        IntendedMeasurementInformation(
+                            intended_measurement_R=burr.intended_measurement_r,
+                            intended_measurement_B=burr.intended_measurement_b,
+                            intended_measurement_G=burr.intended_measurement_g,
+                            intended_measurement_Iso=(
+                                burr.intended_measurement_iso
+                            ),
                         )
+                    )
         all_intended_measurements.extend(
             self._get_intended_measurements(initial_measurements)
         )

--- a/aind-metadata-service-server/src/aind_metadata_service_server/mappers/nsb2023.py
+++ b/aind-metadata-service-server/src/aind_metadata_service_server/mappers/nsb2023.py
@@ -260,7 +260,6 @@ class IntendedMeasurementandCoords:
 
 
 # Define BREGMA_ARD coordinate system (3 axes: AP, ML, Depth)
-# NSB doesn't provide SI dimension data, so we use ARD instead of ARID
 BREGMA_ARD = CoordinateSystem(
     name="BREGMA_ARD",
     origin=Origin.BREGMA,
@@ -717,18 +716,18 @@ class MappedNSBList:
         Returns
         -------
         str
-            The coordinate system name (e.g., "C1C2_ARID")
+            The coordinate system name (e.g., "C1C2_ARD")
         """
         if spinal_origin is None:
-            return "Spinal_ARID"
+            return "Spinal_ARD"
         origin_name = spinal_origin.value
         match = re.search(MappedNSBList.SPINAL_LOCATION_REGEX, origin_name)
         if match:
             first_vertebra = match.group(1)
             second_vertebra = match.group(2)
-            return f"{first_vertebra}{second_vertebra}_ARID"
+            return f"{first_vertebra}{second_vertebra}_ARD"
 
-        return "Spinal_ARID"
+        return "Spinal_ARD"
 
     @property
     def aind_burr_2_d_v_x00(self) -> Optional[Decimal]:
@@ -3539,7 +3538,7 @@ class MappedNSBList:
                     name="TIP_D",
                     origin=Origin.TIP,
                     axis_unit=SizeUnit.MM,
-                    axes=[Axis(name=AxisName.SI, direction=Direction.UD)],
+                    axes=[Axis(name=AxisName.DEPTH, direction=Direction.UD)],
                 )
 
                 transforms = self._map_burr_hole_transforms(

--- a/aind-metadata-service-server/tests/test_mappers/test_nsb2023.py
+++ b/aind-metadata-service-server/tests/test_mappers/test_nsb2023.py
@@ -38,6 +38,7 @@ from aind_sharepoint_service_async_client.models.nsb2023_list import (
 )
 
 from aind_metadata_service_server.mappers.nsb2023 import (
+    BREGMA_ARD,
     BurrHoleInfo,
     BurrHoleProcedure,
     During,
@@ -1199,11 +1200,11 @@ class TestNSB2023FiberImplantMapping(TestCase):
 
             translation, rotation = transform
             self.assertIsInstance(translation, Translation)
-            self.assertEqual(len(translation.translation), 4)
+            self.assertEqual(len(translation.translation), 3)
             self.assertIsInstance(rotation, Rotation)
-            self.assertEqual(len(rotation.angles), 4)
+            self.assertEqual(len(rotation.angles), 3)
             self.assertIsNotNone(surgery.coordinate_system)
-            self.assertEqual(surgery.coordinate_system.name, "BREGMA_ARID")
+            self.assertEqual(surgery.coordinate_system.name, "BREGMA_ARD")
 
 
 class TestNSB2023SpinalInjectionMapping(TestCase):
@@ -1480,8 +1481,8 @@ class TestNSB2023SurgeryIntegration(TestCase):
                 During.INITIAL
             )
         self.assertIsNotNone(coord_sys)
-        # Should be BREGMA_ARID since fiber implants have depth coordinates
-        self.assertEqual(coord_sys, CoordinateSystemLibrary.BREGMA_ARID)
+        # Should be BREGMA_ARD since fiber implants have depth coordinates
+        self.assertEqual(coord_sys, BREGMA_ARD)
 
     def test_map_measured_coordinates(self):
         """Test measured coordinates mapping"""
@@ -1502,15 +1503,16 @@ class TestNSB2023SurgeryIntegration(TestCase):
         self.assertIn(Origin.BREGMA, measured)
         self.assertEqual(len(measured[Origin.BREGMA].translation), 3)
 
-        coord_sys_4d = CoordinateSystemLibrary.BREGMA_ARID
-        measured_4d = MappedNSBList.map_measured_coordinates(
-            Decimal("4.5"), coord_sys_4d
+        # Test with ARD coordinate system (3 axes)
+        coord_sys_ard = BREGMA_ARD
+        measured_ard = MappedNSBList.map_measured_coordinates(
+            Decimal("4.5"), coord_sys_ard
         )
-        self.assertIsNotNone(measured_4d)
-        self.assertIn(Origin.LAMBDA, measured_4d)
-        self.assertEqual(len(measured_4d[Origin.LAMBDA].translation), 4)
+        self.assertIsNotNone(measured_ard)
+        self.assertIn(Origin.LAMBDA, measured_ard)
+        self.assertEqual(len(measured_ard[Origin.LAMBDA].translation), 3)
         self.assertEqual(
-            measured_4d[Origin.LAMBDA].translation, [Decimal("-4.5"), 0, 0, 0]
+            measured_ard[Origin.LAMBDA].translation, [Decimal("-4.5"), 0, 0]
         )
 
         coord_sys_other = CoordinateSystem(
@@ -1707,7 +1709,7 @@ class TestNSB2023CoordinateMapping(TestCase):
             ml=Decimal("2.0"),
             ap=Decimal("1.5"),
             depth=[Decimal("3.0")],
-            surgery_coordinate_system=CoordinateSystemLibrary.BREGMA_ARID,
+            surgery_coordinate_system=BREGMA_ARD,
         )
         self.assertIsInstance(transforms, list)
         self.assertGreater(len(transforms), 0)
@@ -1724,40 +1726,38 @@ class TestNSB2023CoordinateMapping(TestCase):
         self.assertIsInstance(transforms, list)
         self.assertEqual(len(transforms), 1)
 
-    def test_map_burr_hole_transforms_arid_coordinate_system(self):
-        """Test burr hole transforms with ARID coordinate system (4D)"""
-        # Test with BREGMA_ARID (should add 4th dimension)
-        transforms_arid = MappedNSBList._map_burr_hole_transforms(
+    def test_map_burr_hole_transforms_ard_coordinate_system(self):
+        """Test burr hole transforms with ARD coordinate system (3D)"""
+        # Test with BREGMA_ARD (3 axes: AP, ML, Depth)
+        transforms_ard = MappedNSBList._map_burr_hole_transforms(
             angle=Decimal("15"),
             ml=Decimal("2.5"),
             ap=Decimal("1.8"),
             depth=[Decimal("3.5"), Decimal("4.0")],
-            surgery_coordinate_system=CoordinateSystemLibrary.BREGMA_ARID,
+            surgery_coordinate_system=BREGMA_ARD,
         )
 
         # Should have 2 transforms (one per depth)
-        self.assertEqual(len(transforms_arid), 2)
+        self.assertEqual(len(transforms_ard), 2)
 
         # Each transform should have Translation and Rotation
-        for transform in transforms_arid:
+        for transform in transforms_ard:
             self.assertEqual(len(transform), 2)
             translation, rotation = transform
 
-            # ARID should have 4D coordinates
+            # ARD should have 3D coordinates
             self.assertIsInstance(translation, Translation)
-            self.assertEqual(len(translation.translation), 4)
+            self.assertEqual(len(translation.translation), 3)
             self.assertEqual(translation.translation[0], 1.8)
             self.assertEqual(translation.translation[1], 2.5)  # ML
-            self.assertEqual(translation.translation[2], 0)  # SI
-            self.assertIn(translation.translation[3], [3.5, 4.0])  # Depth
+            self.assertIn(translation.translation[2], [3.5, 4.0])  # Depth
 
-            # ARID should have 4D rotation angles
+            # ARD should have 3D rotation angles
             self.assertIsInstance(rotation, Rotation)
-            self.assertEqual(len(rotation.angles), 4)
+            self.assertEqual(len(rotation.angles), 3)
             self.assertEqual(rotation.angles[0], 15)
             self.assertEqual(rotation.angles[1], 0)
             self.assertEqual(rotation.angles[2], 0)
-            self.assertEqual(rotation.angles[3], 0)
 
     def test_map_burr_hole_transforms_ari_coordinate_system(self):
         """Test burr hole transforms with ARI coordinate system (3D)"""
@@ -1792,26 +1792,26 @@ class TestNSB2023CoordinateMapping(TestCase):
             self.assertEqual(rotation.angles[1], 0)
             self.assertEqual(rotation.angles[2], 0)
 
-    def test_map_burr_hole_transforms_no_depth_arid(self):
-        """Test burr hole transforms without depth for ARID system"""
+    def test_map_burr_hole_transforms_no_depth_ard(self):
+        """Test burr hole transforms without depth for ARD system"""
         transforms = MappedNSBList._map_burr_hole_transforms(
             angle=Decimal("10"),
             ml=Decimal("2.0"),
             ap=Decimal("1.5"),
             depth=None,
-            surgery_coordinate_system=CoordinateSystemLibrary.BREGMA_ARID,
+            surgery_coordinate_system=BREGMA_ARD,
         )
 
         # Should have 1 transform
         self.assertEqual(len(transforms), 1)
         translation, rotation = transforms[0]
 
-        # ARID without depth should still have 4D, with missing depth preserved
-        self.assertEqual(len(translation.translation), 4)
-        self.assertIsNone(translation.translation[3])
+        # ARD without depth should have 3D, with missing depth preserved as None
+        self.assertEqual(len(translation.translation), 3)
+        self.assertIsNone(translation.translation[2])
 
-        self.assertEqual(len(rotation.angles), 4)
-        self.assertEqual(rotation.angles[3], 0)
+        self.assertEqual(len(rotation.angles), 3)
+        self.assertEqual(rotation.angles[2], 0)
 
     def test_map_burr_hole_transforms_all_coords_missing(self):
         """If AP/ML/DV are all None, translation should be empty."""
@@ -1820,13 +1820,14 @@ class TestNSB2023CoordinateMapping(TestCase):
             ml=None,
             ap=None,
             depth=None,
-            surgery_coordinate_system=CoordinateSystemLibrary.BREGMA_ARID,
+            surgery_coordinate_system=BREGMA_ARD,
         )
 
         self.assertEqual(len(transforms), 1)
         translation, rotation = transforms[0]
         self.assertEqual(translation.translation, [])
-        self.assertEqual(rotation.angles, [10, 0, 0, 0])
+        # ARD system should have 3 rotation angles
+        self.assertEqual(rotation.angles, [10.0, 0.0, 0.0])
 
     def test_map_burr_hole_transforms_missing_ap_ml_with_dv(self):
         """If any coordinate exists, keep missing values as None, not zero."""
@@ -1835,14 +1836,15 @@ class TestNSB2023CoordinateMapping(TestCase):
             ml=None,
             ap=None,
             depth=[Decimal("3.0")],
-            surgery_coordinate_system=CoordinateSystemLibrary.BREGMA_ARID,
+            surgery_coordinate_system=BREGMA_ARD,
         )
 
         self.assertEqual(len(transforms), 1)
         translation, _ = transforms[0]
+        # ARD system has 3D: [AP, ML, Depth]
         self.assertEqual(
             translation.translation,
-            [None, None, 0, Decimal("3.0")],
+            [None, None, 3.0],
         )
 
     def test_map_burr_hole_transforms_no_depth_ari(self):
@@ -1878,13 +1880,13 @@ class TestNSB2023CoordinateMapping(TestCase):
     def test_map_burr_hole_transforms_spinal_coordinate_system(self):
         """Test burr hole transforms with spinal coordinate system"""
         spinal_coord_sys = CoordinateSystem(
-            name="C1C2_ARID",
+            name="C1C2_ARD",
             origin=Origin.BETWEEN_C1_C2,
             axis_unit=SizeUnit.MM,
             axes=[
                 Axis(name=AxisName.AP, direction=Direction.PA),
                 Axis(name=AxisName.ML, direction=Direction.LR),
-                Axis(name=AxisName.SI, direction=Direction.SI),
+                Axis(name=AxisName.DEPTH, direction=Direction.UD),
             ],
         )
 
@@ -1896,11 +1898,11 @@ class TestNSB2023CoordinateMapping(TestCase):
             surgery_coordinate_system=spinal_coord_sys,
         )
 
-        # Should treat as ARID (4D) since name ends with "ARID"
+        # Should treat as ARD (3D) since name ends with "ARD"
         self.assertEqual(len(transforms), 1)
         translation, rotation = transforms[0]
-        self.assertEqual(len(translation.translation), 4)
-        self.assertEqual(len(rotation.angles), 4)
+        self.assertEqual(len(translation.translation), 3)
+        self.assertEqual(len(rotation.angles), 3)
 
     def test_map_burr_hole_dv_list(self):
         """Test DV coordinate list mapping"""

--- a/aind-metadata-service-server/tests/test_mappers/test_nsb2023.py
+++ b/aind-metadata-service-server/tests/test_mappers/test_nsb2023.py
@@ -1192,7 +1192,7 @@ class TestNSB2023FiberImplantMapping(TestCase):
             self.assertEqual(coord_sys.origin, Origin.TIP)
             self.assertEqual(coord_sys.axis_unit, SizeUnit.MM)
             self.assertEqual(len(coord_sys.axes), 1)
-            self.assertEqual(coord_sys.axes[0].name, AxisName.SI)
+            self.assertEqual(coord_sys.axes[0].name, AxisName.DEPTH)
             self.assertEqual(coord_sys.axes[0].direction, Direction.UD)
             self.assertIsNotNone(probe_implant.device_config.transform)
             transform = probe_implant.device_config.transform
@@ -1229,20 +1229,20 @@ class TestNSB2023SpinalInjectionMapping(TestCase):
         c1c2_name = MappedNSBList._get_spinal_coordinate_system_name(
             Origin.BETWEEN_C1_C2
         )
-        self.assertEqual(c1c2_name, "C1C2_ARID")
+        self.assertEqual(c1c2_name, "C1C2_ARD")
 
         none_name = MappedNSBList._get_spinal_coordinate_system_name(None)
-        self.assertEqual(none_name, "Spinal_ARID")
+        self.assertEqual(none_name, "Spinal_ARD")
 
         tip_name = MappedNSBList._get_spinal_coordinate_system_name(Origin.TIP)
-        self.assertEqual(tip_name, "Spinal_ARID")
+        self.assertEqual(tip_name, "Spinal_ARD")
 
     def test_map_various_spinal_locations(self):
         """Test different spinal location mappings"""
         test_cases = [
-            ("Between C2-C3", Origin.BETWEEN_C2_C3, "C2C3_ARID"),
-            ("Between C3-C4", Origin.BETWEEN_C3_C4, "C3C4_ARID"),
-            ("Between T1-T2", Origin.BETWEEN_T1_T2, "T1T2_ARID"),
+            ("Between C2-C3", Origin.BETWEEN_C2_C3, "C2C3_ARD"),
+            ("Between C3-C4", Origin.BETWEEN_C3_C4, "C3C4_ARD"),
+            ("Between T1-T2", Origin.BETWEEN_T1_T2, "T1T2_ARD"),
         ]
 
         for location_str, expected_origin, expected_coord_name in test_cases:
@@ -1279,7 +1279,7 @@ class TestNSB2023SpinalInjectionMapping(TestCase):
             During.FOLLOW_UP
         )
         self.assertIsNotNone(coord_sys)
-        self.assertEqual(coord_sys.name, "T1T2_ARID")
+        self.assertEqual(coord_sys.name, "T1T2_ARD")
         self.assertEqual(coord_sys.origin, Origin.BETWEEN_T1_T2)
 
     def test_get_surgeries_spinal_injection(self):
@@ -1516,7 +1516,7 @@ class TestNSB2023SurgeryIntegration(TestCase):
         )
 
         coord_sys_other = CoordinateSystem(
-            name="C1C2_ARID",
+            name="C1C2_ARD",
             origin=Origin.BETWEEN_C1_C2,
             axis_unit=SizeUnit.MM,
             axes=[
@@ -1806,7 +1806,6 @@ class TestNSB2023CoordinateMapping(TestCase):
         self.assertEqual(len(transforms), 1)
         translation, rotation = transforms[0]
 
-        # ARD without depth should have 3D, with missing depth preserved as None
         self.assertEqual(len(translation.translation), 3)
         self.assertIsNone(translation.translation[2])
 


### PR DESCRIPTION
closes #635 

This PR: 
- Updates all `BREGMA_ARID` coord systems to `BREGMA_ARD`
- Updates all translations/rotations to 3 axes
- Updated `TIP_D` system to use Depth axis instead of SI axis