### PR TITLE
fix: ccf acronym regex, feat: handles None str intended measurements

### DIFF
--- a/aind-metadata-service-server/pyproject.toml
+++ b/aind-metadata-service-server/pyproject.toml
@@ -22,7 +22,7 @@ dependencies = [
     'aind-slims-service-async-client>=0.3.2',
     'aind-tars-service-async-client>=0.1.3',
     'aind-smartsheet-service-async-client>=0.3.1',
-    'aind-sharepoint-service-async-client>=0.2.0',
+    'aind-sharepoint-service-async-client>=0.3.0',
     'aind-session-json-service-async-client>=0.1.3',
     'aind-data-schema==1.4.0',
     'aind-data-schema-models==0.7.5',

--- a/aind-metadata-service-server/src/aind_metadata_service_server/mappers/nsb2023.py
+++ b/aind-metadata-service-server/src/aind_metadata_service_server/mappers/nsb2023.py
@@ -269,7 +269,7 @@ class MappedNSBList:
     )
     CONCENTRATION_REGEX = re.compile(r"^\d+(\.\d+)?\s*mg[/]m[lL]$")
     LENGTH_MM_REGEX = re.compile(r"^([1-9]\.\d) mm$")
-    INTENDED_TARGET_REGEX = re.compile(r"^([A-Z_]+(?:/[A-Z_]+)*)\s*-")
+    INTENDED_TARGET_REGEX = re.compile(r"^([A-Za-z0-9_-]+(?:/[A-Za-z0-9_-]+)*)\s+-")
 
     # Mapping from CCF structure acronym to CCFStructure object
     SCHEMA_ACRONYM_MAP = {m().acronym: m() for m in CCFStructure.ALL}
@@ -1134,7 +1134,8 @@ class MappedNSBList:
         return (
             None
             if intended is None
-            or intended.value == getattr(intended, "N_A", None)
+            or intended == getattr(intended, "N_A", None)
+            or intended == getattr(intended, "SELECT", None)
             else intended.value
         )
 
@@ -1146,7 +1147,9 @@ class MappedNSBList:
         )
         return (
             None
-            if intended is None or intended == getattr(intended, "N_A", None)
+            if intended is None
+            or intended == getattr(intended, "N_A", None)
+            or intended == getattr(intended, "SELECT", None)
             else intended.value
         )
 
@@ -1158,7 +1161,9 @@ class MappedNSBList:
         )
         return (
             None
-            if intended is None or intended == getattr(intended, "N_A", None)
+            if intended is None
+            or intended == getattr(intended, "N_A", None)
+            or intended == getattr(intended, "SELECT", None)
             else intended.value
         )
 
@@ -1170,7 +1175,9 @@ class MappedNSBList:
         )
         return (
             None
-            if intended is None or intended == getattr(intended, "N_A", None)
+            if intended is None
+            or intended == getattr(intended, "N_A", None)
+            or intended == getattr(intended, "SELECT", None)
             else intended.value
         )
 
@@ -1280,7 +1287,9 @@ class MappedNSBList:
         )
         return (
             None
-            if intended is None or intended == getattr(intended, "N_A", None)
+            if intended is None
+            or intended == getattr(intended, "N_A", None)
+            or intended == getattr(intended, "SELECT", None)
             else intended.value
         )
 
@@ -1292,7 +1301,9 @@ class MappedNSBList:
         )
         return (
             None
-            if intended is None or intended == getattr(intended, "N_A", None)
+            if intended is None
+            or intended == getattr(intended, "N_A", None)
+            or intended == getattr(intended, "SELECT", None)
             else intended.value
         )
 
@@ -1304,7 +1315,9 @@ class MappedNSBList:
         )
         return (
             None
-            if intended is None or intended == getattr(intended, "N_A", None)
+            if intended is None
+            or intended == getattr(intended, "N_A", None)
+            or intended == getattr(intended, "SELECT", None)
             else intended.value
         )
 
@@ -1316,7 +1329,9 @@ class MappedNSBList:
         )
         return (
             None
-            if intended is None or intended == getattr(intended, "N_A", None)
+            if intended is None
+            or intended == getattr(intended, "N_A", None)
+            or intended == getattr(intended, "SELECT", None)
             else intended.value
         )
 
@@ -1444,7 +1459,9 @@ class MappedNSBList:
         )
         return (
             None
-            if intended is None or intended == getattr(intended, "N_A", None)
+            if intended is None
+            or intended == getattr(intended, "N_A", None)
+            or intended == getattr(intended, "SELECT", None)
             else intended.value
         )
 
@@ -1456,7 +1473,9 @@ class MappedNSBList:
         )
         return (
             None
-            if intended is None or intended == getattr(intended, "N_A", None)
+            if intended is None
+            or intended == getattr(intended, "N_A", None)
+            or intended == getattr(intended, "SELECT", None)
             else intended.value
         )
 
@@ -1468,7 +1487,9 @@ class MappedNSBList:
         )
         return (
             None
-            if intended is None or intended == getattr(intended, "N_A", None)
+            if intended is None
+            or intended == getattr(intended, "N_A", None)
+            or intended == getattr(intended, "SELECT", None)
             else intended.value
         )
 
@@ -1480,7 +1501,9 @@ class MappedNSBList:
         )
         return (
             None
-            if intended is None or intended == getattr(intended, "N_A", None)
+            if intended is None
+            or intended == getattr(intended, "N_A", None)
+            or intended == getattr(intended, "SELECT", None)
             else intended.value
         )
 
@@ -1589,7 +1612,9 @@ class MappedNSBList:
         )
         return (
             None
-            if intended is None or intended == getattr(intended, "N_A", None)
+            if intended is None
+            or intended == getattr(intended, "N_A", None)
+            or intended == getattr(intended, "SELECT", None)
             else intended.value
         )
 
@@ -1601,7 +1626,9 @@ class MappedNSBList:
         )
         return (
             None
-            if intended is None or intended == getattr(intended, "N_A", None)
+            if intended is None
+            or intended == getattr(intended, "N_A", None)
+            or intended == getattr(intended, "SELECT", None)
             else intended.value
         )
 
@@ -1613,7 +1640,9 @@ class MappedNSBList:
         )
         return (
             None
-            if intended is None or intended == getattr(intended, "N_A", None)
+            if intended is None
+            or intended == getattr(intended, "N_A", None)
+            or intended == getattr(intended, "SELECT", None)
             else intended.value
         )
 
@@ -1625,7 +1654,9 @@ class MappedNSBList:
         )
         return (
             None
-            if intended is None or intended == getattr(intended, "N_A", None)
+            if intended is None
+            or intended == getattr(intended, "N_A", None)
+            or intended == getattr(intended, "SELECT", None)
             else intended.value
         )
 
@@ -1748,7 +1779,9 @@ class MappedNSBList:
         )
         return (
             None
-            if intended is None or intended == getattr(intended, "N_A", None)
+            if intended is None
+            or intended == getattr(intended, "N_A", None)
+            or intended == getattr(intended, "SELECT", None)
             else intended.value
         )
 
@@ -1760,7 +1793,9 @@ class MappedNSBList:
         )
         return (
             None
-            if intended is None or intended == getattr(intended, "N_A", None)
+            if intended is None
+            or intended == getattr(intended, "N_A", None)
+            or intended == getattr(intended, "SELECT", None)
             else intended.value
         )
 
@@ -1772,7 +1807,9 @@ class MappedNSBList:
         )
         return (
             None
-            if intended is None or intended == getattr(intended, "N_A", None)
+            if intended is None
+            or intended == getattr(intended, "N_A", None)
+            or intended == getattr(intended, "SELECT", None)
             else intended.value
         )
 
@@ -1784,7 +1821,9 @@ class MappedNSBList:
         )
         return (
             None
-            if intended is None or intended == getattr(intended, "N_A", None)
+            if intended is None
+            or intended == getattr(intended, "N_A", None)
+            or intended == getattr(intended, "SELECT", None)
             else intended.value
         )
 
@@ -1914,7 +1953,9 @@ class MappedNSBList:
         )
         return (
             None
-            if intended is None or intended == getattr(intended, "N_A", None)
+            if intended is None
+            or intended == getattr(intended, "N_A", None)
+            or intended == getattr(intended, "SELECT", None)
             else intended.value
         )
 
@@ -1926,7 +1967,9 @@ class MappedNSBList:
         )
         return (
             None
-            if intended is None or intended == getattr(intended, "N_A", None)
+            if intended is None
+            or intended == getattr(intended, "N_A", None)
+            or intended == getattr(intended, "SELECT", None)
             else intended.value
         )
 
@@ -1938,7 +1981,9 @@ class MappedNSBList:
         )
         return (
             None
-            if intended is None or intended == getattr(intended, "N_A", None)
+            if intended is None
+            or intended == getattr(intended, "N_A", None)
+            or intended == getattr(intended, "SELECT", None)
             else intended.value
         )
 
@@ -1950,7 +1995,9 @@ class MappedNSBList:
         )
         return (
             None
-            if intended is None or intended == getattr(intended, "N_A", None)
+            if intended is None
+            or intended == getattr(intended, "N_A", None)
+            or intended == getattr(intended, "SELECT", None)
             else intended.value
         )
 

--- a/aind-metadata-service-server/src/aind_metadata_service_server/mappers/nsb2023.py
+++ b/aind-metadata-service-server/src/aind_metadata_service_server/mappers/nsb2023.py
@@ -269,7 +269,9 @@ class MappedNSBList:
     )
     CONCENTRATION_REGEX = re.compile(r"^\d+(\.\d+)?\s*mg[/]m[lL]$")
     LENGTH_MM_REGEX = re.compile(r"^([1-9]\.\d) mm$")
-    INTENDED_TARGET_REGEX = re.compile(r"^([A-Za-z0-9_-]+(?:/[A-Za-z0-9_-]+)*)\s+-")
+    INTENDED_TARGET_REGEX = re.compile(
+        r"^([A-Za-z0-9_-]+(?:/[A-Za-z0-9_-]+)*)\s+-"
+    )
 
     # Mapping from CCF structure acronym to CCFStructure object
     SCHEMA_ACRONYM_MAP = {m().acronym: m() for m in CCFStructure.ALL}

--- a/aind-metadata-service-server/tests/test_mappers/test_intended_measurements.py
+++ b/aind-metadata-service-server/tests/test_mappers/test_intended_measurements.py
@@ -191,6 +191,38 @@ class TestIntendedMeasurementMapper(unittest.TestCase):
         self.assertIsNone(measurements[0].intended_measurement_B)
         self.assertIsNone(measurements[0].intended_measurement_Iso)
 
+    def test_measurements_with_none(self):
+        """Test measurements with None values."""
+        nsb_data = {
+            "FileSystemObjectType": 0,
+            "Id": 3,
+            "Burr_x0020_hole_x0020_1": "Stereotaxic Injection & Fiber Implant",
+            "Burr1_x0020_Perform_x0020_During": "Initial Surgery",
+            "Burr_x0020_Hole_x0020_1_x0020_st": "Complete",
+            "Virus_x0020_A_x002f_P": 1.0,
+            "Virus_x0020_M_x002f_L": 1.5,
+            "Burr_x0020_1_x0020_intended_x0020": "acetylcholine",
+            "Burr_x0020_1_x0020_intended_x0021": "None",
+            "Burr_x0020_1_x0020_intended_x0022": "Select...",
+            "Burr_x0020_1_x0020_intended_x0023": "N/A",
+        }
+        nsb_model = NSB2023List.model_validate(nsb_data)
+        mapper = IntendedMeasurementMapper(
+            nsb_2023=[nsb_model], nsb_present=[]
+        )
+        measurements = mapper.map_responses_to_intended_measurements(
+            subject_id="test_subject"
+        )
+        print(measurements)
+        self.assertEqual(len(measurements), 1)
+        self.assertEqual(measurements[0].fiber_name, "Fiber_0")
+        self.assertEqual(
+            measurements[0].intended_measurement_R, "acetylcholine"
+        )
+        self.assertEqual(measurements[0].intended_measurement_G, "None")
+        self.assertIsNone(measurements[0].intended_measurement_B)
+        self.assertIsNone(measurements[0].intended_measurement_Iso)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/aind-metadata-service-server/tests/test_mappers/test_intended_measurements.py
+++ b/aind-metadata-service-server/tests/test_mappers/test_intended_measurements.py
@@ -213,7 +213,6 @@ class TestIntendedMeasurementMapper(unittest.TestCase):
         measurements = mapper.map_responses_to_intended_measurements(
             subject_id="test_subject"
         )
-        print(measurements)
         self.assertEqual(len(measurements), 1)
         self.assertEqual(measurements[0].fiber_name, "Fiber_0")
         self.assertEqual(

--- a/aind-metadata-service-server/tests/test_mappers/test_nsb2023.py
+++ b/aind-metadata-service-server/tests/test_mappers/test_nsb2023.py
@@ -15,7 +15,10 @@ from aind_data_schema.core.procedures import (
     CraniotomyType,
     HeadframeMaterial,
 )
-from aind_data_schema_models.brain_atlas import _BrainStructureModel, CCFStructure
+from aind_data_schema_models.brain_atlas import (
+    _BrainStructureModel,
+    CCFStructure,
+)
 from aind_sharepoint_service_async_client.models.nsb2023_list import (
     NSB2023List,
 )
@@ -402,7 +405,7 @@ class TestNSB2023Parsers(TestCase):
         """Tests that all CCF acronyms can be parsed correctly by the regex"""
         nsb_model = NSB2023List.model_construct()
         mapper = MappedNSBList(nsb=nsb_model)
-        
+
         all_acronyms = {m().acronym for m in CCFStructure.ALL}
         failed_acronyms = []
         for acronym in all_acronyms:
@@ -412,7 +415,7 @@ class TestNSB2023Parsers(TestCase):
                 failed_acronyms.append(acronym)
             else:
                 self.assertEqual(result.acronym, acronym)
-        # Some of these need to be fixed in NSB, log failed acronyms instead of asserting
+        # 3 need to be fixed in NSB, log failed acronyms instead of asserting
         logging.debug(f"Failed CCF acronyms: {failed_acronyms}")
 
     def test_ma_custom_hp_and_cran_procedures(self):

--- a/aind-metadata-service-server/tests/test_mappers/test_nsb2023.py
+++ b/aind-metadata-service-server/tests/test_mappers/test_nsb2023.py
@@ -15,7 +15,7 @@ from aind_data_schema.core.procedures import (
     CraniotomyType,
     HeadframeMaterial,
 )
-from aind_data_schema_models.brain_atlas import _BrainStructureModel
+from aind_data_schema_models.brain_atlas import _BrainStructureModel, CCFStructure
 from aind_sharepoint_service_async_client.models.nsb2023_list import (
     NSB2023List,
 )
@@ -397,6 +397,23 @@ class TestNSB2023Parsers(TestCase):
                 data["Burr_x0020_2_x0020_Intended_x002"][0]
             )
         )
+
+    def test_map_all_ccf_acronyms(self):
+        """Tests that all CCF acronyms can be parsed correctly by the regex"""
+        nsb_model = NSB2023List.model_construct()
+        mapper = MappedNSBList(nsb=nsb_model)
+        
+        all_acronyms = {m().acronym for m in CCFStructure.ALL}
+        failed_acronyms = []
+        for acronym in all_acronyms:
+            test_string = f"{acronym} - Test Structure"
+            result = mapper._map_targeted_structure(test_string)
+            if result is None:
+                failed_acronyms.append(acronym)
+            else:
+                self.assertEqual(result.acronym, acronym)
+        # Some of these need to be fixed in NSB, log failed acronyms instead of asserting
+        logging.debug(f"Failed CCF acronyms: {failed_acronyms}")
 
     def test_ma_custom_hp_and_cran_procedures(self):
         """Tests custom procedure with headpost and cran."""

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -27,7 +27,7 @@ services:
     image: "ghcr.io/allenneuraldynamics/aind-slims-service-server:0.3.2"
     env_file: "env/slims.env"
   sharepoint:
-    image: "ghcr.io/allenneuraldynamics/aind-sharepoint-service-server:0.2.0"
+    image: "ghcr.io/allenneuraldynamics/aind-sharepoint-service-server:0.3.0"
     env_file: "env/sharepoint.env"
   tars:
     image: "ghcr.io/allenneuraldynamics/aind-tars-service-server:0.1.3"


### PR DESCRIPTION
closes #703 , #705 for V1

This PR: 
- Updates the sharepoint client version (updated with new intended measurement values "None" and "Select...")
- Updates intended measurement mappings to return `None` when it is the default value "Select...". 
- Intended measurement mappings are expected to return "None" if the user selected "None" in the form (differs from default "Select..." or previously "N/A")
- Fixes the CCF acronym regex pattern for parsing the CCF acronym from NSB list

Note: 
- Added a test to test all acronyms. Right now, 3 of them are failing due to bugs in NSB. Looped in @dbirman and Ali. This will be fixed in NSB, so the unit test for now just logs the failed acronyms. The test can also be removed if we don't want to log it, but it'll be useful to check for stuff like this
```
CUL4 5 - NSB has it with a space "CUL4 5", but CCF model has "CUL4, 5" 
ORBv - NSB has 'Orbital area ventral part' but CCF model doesn't have this exact acronym. (There's ORBvl, ORBvl1, ORBvl2/3...)
PMR - Is a typo in NSB. Should be PRM.
```