### PR TITLE
feat: filter out surgeries with no surgery status

### DIFF
--- a/aind-metadata-service-server/pyproject.toml
+++ b/aind-metadata-service-server/pyproject.toml
@@ -21,7 +21,7 @@ dependencies = [
     'aind-mgi-service-async-client>=0.1.2',
     'aind-slims-service-async-client>=0.3.4',
     'aind-tars-service-async-client>=0.1.3',
-    'aind-smartsheet-service-async-client>=0.3.1',
+    'aind-smartsheet-service-async-client==0.3.1',
     'aind-sharepoint-service-async-client>=0.3.0',
     'aind-session-json-service-async-client>=0.1.3',
     'aind-dataverse-service-async-client>=0.1.0',

--- a/aind-metadata-service-server/src/aind_metadata_service_server/mappers/nsb2019.py
+++ b/aind-metadata-service-server/src/aind_metadata_service_server/mappers/nsb2019.py
@@ -40,6 +40,7 @@ from aind_data_schema_models.units import (
 )
 from aind_sharepoint_service_async_client.models import (
     NSB2019List,
+    NSB2019SurgeryStatus,
 )
 from pydantic import ValidationError
 
@@ -1355,8 +1356,21 @@ class MappedNSBList:
                 origin = Origin.BREGMA
             return {origin: Translation(translation=[b2l_dist, 0, 0])}
 
+    def has_surgery(self) -> bool:
+        """Is there a surgery?"""
+        return (
+            False
+            if self._nsb.surgery_status is None
+            or self._nsb.surgery_status == NSB2019SurgeryStatus.NO_SURGERY
+            else True
+        )
+
     def get_surgeries(self) -> List[Surgery]:
         """Return Surgery as best as possible from a record."""
+
+        # Check if item has been explicitly marked as No Surgery
+        if not self.has_surgery():
+            return []
 
         experimenters = [self.aind_experimenter_full_name]
         ethics_review_id = self.aind_iacuc_protocol

--- a/aind-metadata-service-server/src/aind_metadata_service_server/mappers/nsb2023.py
+++ b/aind-metadata-service-server/src/aind_metadata_service_server/mappers/nsb2023.py
@@ -48,6 +48,7 @@ from aind_sharepoint_service_async_client.models import (
     NSB2023List,
     NSB2023Procedure,
     NSB2023IacucProtocol as IacucProtocol,
+    NSB2023SurgeryStatus,
 )
 from pydantic import ValidationError
 
@@ -2514,6 +2515,15 @@ class MappedNSBList:
             }.get(self._nsb.burr6_x0020_status, None)
         )
 
+    def has_surgery(self) -> bool:
+        """Is there a surgery?"""
+        return (
+            False
+            if self._nsb.surgery_status is None
+            or self._nsb.surgery_status == NSB2023SurgeryStatus.NO_SURGERY
+            else True
+        )
+
     # TODO: support new Procedures
     # (EMG Array, Grid Injections, Testes, Oviduct)
     def has_hp_procedure(self) -> bool:
@@ -3406,8 +3416,11 @@ class MappedNSBList:
     def get_surgeries(self) -> List[Surgery]:
         """Get a List of Surgeries."""
 
-        surgeries = []
+        # Check if item has been explicitly marked as No Surgery
+        if not self.has_surgery():
+            return []
 
+        surgeries = []
         # Surgery info
         initial_start_date = self.aind_date_of_surgery
         initial_animal_weight_prior = self.aind_weight_before_surger

--- a/aind-metadata-service-server/tests/test_mappers/test_nsb2019.py
+++ b/aind-metadata-service-server/tests/test_mappers/test_nsb2019.py
@@ -64,6 +64,7 @@ class TestNSB2019BasicMapping(TestCase):
             "Breg2Lamb": "4",
             "AuthorId": 187,
             "Date2ndInjection": None,
+            "SurgeryStatus": "Ready for Feedback",
         }
         cls.nsb_model = NSB2019List.model_validate(cls.basic_nsb_data)
         cls.mapper = MappedNSBList(nsb=cls.nsb_model)
@@ -125,6 +126,7 @@ class TestNSB2019HeadframeMapping(TestCase):
             "Procedure": "HP+Injection+Optic Fiber Implant",
             "Date_x0020_of_x0020_Surgery": "2022-12-06T08:00:00Z",
             "IACUC_x0020_Protocol_x0020__x002": "2115",
+            "SurgeryStatus": "Ready for Feedback",
         }
         cls.nsb_model = NSB2019List.model_validate(cls.headframe_data)
         cls.mapper = MappedNSBList(nsb=cls.nsb_model)
@@ -206,6 +208,7 @@ class TestNSB2019CraniotomyMapping(TestCase):
             "HPDurotomy": "Yes",
             "Date_x0020_of_x0020_Surgery": "2022-12-06T08:00:00Z",
             "IACUC_x0020_Protocol_x0020__x002": "2115",
+            "SurgeryStatus": "Ready for Feedback",
         }
         cls.nsb_model = NSB2019List.model_validate(cls.craniotomy_data)
         cls.mapper = MappedNSBList(nsb=cls.nsb_model)
@@ -288,6 +291,7 @@ class TestNSB2019InjectionMapping(TestCase):
             "FirstInjectionIsoDuration": "1 hour",
             "IACUC_x0020_Protocol_x0020__x002": "2115",
             "Breg2Lamb": "4",
+            "SurgeryStatus": "Ready for Feedback",
         }
         cls.nsb_model = NSB2019List.model_validate(cls.injection_data)
         cls.mapper = MappedNSBList(nsb=cls.nsb_model)
@@ -587,6 +591,7 @@ class TestNSB2019FiberImplantMapping(TestCase):
             "Inj2Angle_v2": "90",
             "Date_x0020_of_x0020_Surgery": "2022-12-06T08:00:00Z",
             "IACUC_x0020_Protocol_x0020__x002": "2115",
+            "SurgeryStatus": "Ready for Feedback",
         }
         cls.nsb_model = NSB2019List.model_validate(cls.fiber_data)
         cls.mapper = MappedNSBList(nsb=cls.nsb_model)
@@ -659,6 +664,7 @@ class TestNSB2019SurgeryIntegration(TestCase):
             "AuthorId": 187,
             "Round1InjIsolevel": None,
             "Round2InjIsolevel": None,
+            "SurgeryStatus": "Ready for Feedback",
         }
         cls.nsb_model = NSB2019List.model_validate(cls.full_surgery_data)
         cls.mapper = MappedNSBList(nsb=cls.nsb_model)
@@ -782,6 +788,7 @@ class TestNSB2019SurgeryIntegration(TestCase):
             "FileSystemObjectType": 0,
             "Id": 1,
             "Date_x0020_of_x0020_Surgery": "2022-12-06T08:00:00Z",
+            "SurgeryStatus": "Ready for Feedback",
         }
         nsb_model = NSB2019List.model_validate(nsb_data)
         mapper = MappedNSBList(nsb=nsb_model)
@@ -887,6 +894,24 @@ class TestNSB2019SurgeryIntegration(TestCase):
             )
             self.assertEqual(second_injection_surgery.animal_weight_post, 19.3)
             self.assertEqual(second_injection_surgery.workstation_id, "SWS 4")
+
+    def test_get_surgeries_no_surgery_status(self):
+        """Test get_surgeries when surgery status is NO_SURGERY"""
+        nsb_data = deepcopy(self.full_surgery_data)
+        nsb_data["SurgeryStatus"] = "No Surgery"
+        nsb_model = NSB2019List.model_validate(nsb_data)
+        mapper = MappedNSBList(nsb=nsb_model)
+        surgeries = mapper.get_surgeries()
+        self.assertEqual(len(surgeries), 0)
+
+    def test_get_surgeries_none_surgery_status(self):
+        """Test get_surgeries when surgery status is None"""
+        nsb_data = deepcopy(self.full_surgery_data)
+        nsb_data["SurgeryStatus"] = None
+        nsb_model = NSB2019List.model_validate(nsb_data)
+        mapper = MappedNSBList(nsb=nsb_model)
+        surgeries = mapper.get_surgeries()
+        self.assertEqual(len(surgeries), 0)
 
 
 class TestNSB2019CoordinateMapping(TestCase):

--- a/aind-metadata-service-server/tests/test_mappers/test_nsb2023.py
+++ b/aind-metadata-service-server/tests/test_mappers/test_nsb2023.py
@@ -76,6 +76,7 @@ class TestNSB2023BasicMapping(TestCase):
             "IACUC_x0020_Protocol_x0020__x002": "2103",
             "Breg2Lamb": -4.5,
             "Protocol": "2119 - Training and qualification of animal users",
+            "SurgeryStatus": "Ready for Feedback",
         }
         cls.nsb_model = NSB2023List.model_validate(cls.basic_nsb_data)
         cls.mapper = MappedNSBList(nsb=cls.nsb_model)
@@ -126,6 +127,7 @@ class TestNSB2023HeadframeMapping(TestCase):
             "Procedure": "Stereotaxic Injection (with Headpost)",
             "Date_x0020_of_x0020_Surgery": "2022-01-03",
             "IACUC_x0020_Protocol_x0020__x002": "2103",
+            "SurgeryStatus": "Ready for Feedback",
         }
         cls.nsb_model = NSB2023List.model_validate(cls.headframe_data)
         cls.mapper = MappedNSBList(nsb=cls.nsb_model)
@@ -285,6 +287,7 @@ class TestNSB2023HeadframeMapping(TestCase):
             "Procedure": "HP Only",
             "IACUC_x0020_Protocol_x0020__x002": "2103",
             "Test1LookupId": 2846,
+            "SurgeryStatus": "Ready for Feedback",
         }
         nsb_model = NSB2023List.model_validate(nsb_data)
         mapper = MappedNSBList(nsb=nsb_model)
@@ -307,6 +310,7 @@ class TestNSB2023HeadframeMapping(TestCase):
             "Procedure": "HP Only",
             "IACUC_x0020_Protocol_x0020__x002": "2103",
             "Breg2Lamb": 4.5,
+            "SurgeryStatus": "Ready for Feedback",
         }
         nsb_model = NSB2023List.model_validate(nsb_data)
         mapper = MappedNSBList(nsb=nsb_model)
@@ -330,6 +334,7 @@ class TestNSB2023HeadframeMapping(TestCase):
             "Procedure": "Custom",
             "IACUC_x0020_Protocol_x0020__x002": "2103",
             "Breg2Lamb": 4.5,
+            "SurgeryStatus": "Ready for Feedback",
         }
         nsb_model = NSB2023List.model_validate(nsb_data)
         mapper = MappedNSBList(nsb=nsb_model)
@@ -361,6 +366,7 @@ class TestNSB2023CraniotomyMapping(TestCase):
             "HeadpostType": "Mesoscope",
             "Date_x0020_of_x0020_Surgery": "2022-01-03",
             "IACUC_x0020_Protocol_x0020__x002": "2103",
+            "SurgeryStatus": "Ready for Feedback",
         }
         cls.craniotomy_data_3mm = {
             "FileSystemObjectType": 0,
@@ -370,6 +376,7 @@ class TestNSB2023CraniotomyMapping(TestCase):
             "Procedure": "Sx-01 Visual Ctx 2P",
             "Date_x0020_of_x0020_Surgery": "2022-01-03",
             "IACUC_x0020_Protocol_x0020__x002": "2103",
+            "SurgeryStatus": "Ready for Feedback",
         }
         cls.nsb_model_5mm = NSB2023List.model_validate(cls.craniotomy_data_5mm)
         cls.mapper_5mm = MappedNSBList(nsb=cls.nsb_model_5mm)
@@ -554,6 +561,7 @@ class TestNSB2023CraniotomyMapping(TestCase):
             "HeadpostType": "Mesoscope",
             "IACUC_x0020_Protocol_x0020__x002": "2103",
             "Test1LookupId": 2846,
+            "SurgeryStatus": "Ready for Feedback",
         }
         nsb_model = NSB2023List.model_validate(nsb_data)
         mapper = MappedNSBList(nsb=nsb_model)
@@ -580,6 +588,7 @@ class TestNSB2023CraniotomyMapping(TestCase):
             "IACUC_x0020_Protocol_x0020__x002": "2103",
             "Test1LookupId": 2846,
             "Breg2Lamb": 4.5,
+            "SurgeryStatus": "Ready for Feedback",
         }
         nsb_model = NSB2023List.model_validate(nsb_data)
         mapper = MappedNSBList(nsb=nsb_model)
@@ -603,6 +612,7 @@ class TestNSB2023CraniotomyMapping(TestCase):
             "HeadpostType": "Mesoscope",
             "IACUC_x0020_Protocol_x0020__x002": "2103",
             "Breg2Lamb": 4.5,
+            "SurgeryStatus": "Ready for Feedback",
         }
         nsb_model = NSB2023List.model_validate(nsb_data)
         mapper = MappedNSBList(nsb=nsb_model)
@@ -632,6 +642,7 @@ class TestNSB2023CraniotomyMapping(TestCase):
             "Date_x0020_of_x0020_Surgery": "2022-01-03",
             "IACUC_x0020_Protocol_x0020__x002": "2103",
             "Breg2Lamb": 4.5,
+            "SurgeryStatus": "Ready for Feedback",
         }
         nsb_model = NSB2023List.model_validate(nsb_data)
         mapper = MappedNSBList(nsb=nsb_model)
@@ -670,6 +681,7 @@ class TestNSB2023InjectionMapping(TestCase):
             "Burr_x0020_2_x0020_Intended_x002": [
                 "FRP - Frontal pole cerebral cortex"
             ],
+            "SurgeryStatus": "Ready for Feedback",
         }
         cls.nsb_model = NSB2023List.model_validate(cls.injection_data)
         cls.mapper = MappedNSBList(nsb=cls.nsb_model)
@@ -780,6 +792,7 @@ class TestNSB2023InjectionMapping(TestCase):
             "Inj1IontoTime": "10 min",
             "IACUC_x0020_Protocol_x0020__x002": "2103",
             "Test1LookupId": 2846,
+            "SurgeryStatus": "Ready for Feedback",
         }
         nsb_model = NSB2023List.model_validate(nsb_data)
         mapper = MappedNSBList(nsb=nsb_model)
@@ -810,6 +823,7 @@ class TestNSB2023InjectionMapping(TestCase):
             "Inj1LenghtofTime": "5 min",
             "IACUC_x0020_Protocol_x0020__x002": "2103",
             "Test1LookupId": 2846,
+            "SurgeryStatus": "Ready for Feedback",
         }
         nsb_model = NSB2023List.model_validate(nsb_data)
         mapper = MappedNSBList(nsb=nsb_model)
@@ -838,6 +852,7 @@ class TestNSB2023InjectionMapping(TestCase):
             "IACUC_x0020_Protocol_x0020__x002": "2103",
             "Test1LookupId": 2846,
             "Inj1Type": "Nanoject (Pressure)",
+            "SurgeryStatus": "Ready for Feedback",
         }
         nsb_model = NSB2023List.model_validate(nsb_data)
         mapper = MappedNSBList(nsb=nsb_model)
@@ -861,6 +876,7 @@ class TestNSB2023InjectionMapping(TestCase):
             "Virus_x0020_A_x002f_P": 3.0,
             "Virus_x0020_D_x002f_V": 4.0,
             "IACUC_x0020_Protocol_x0020__x002": "2103",
+            "SurgeryStatus": "Ready for Feedback",
         }
         nsb_model = NSB2023List.model_validate(nsb_data)
         mapper = MappedNSBList(nsb=nsb_model)
@@ -965,6 +981,7 @@ class TestNSB2023InjectionMapping(TestCase):
             "Inj1IontoTime": "10 min",
             "IACUC_x0020_Protocol_x0020__x002": "2103",
             "Test1LookupId": 2846,
+            "SurgeryStatus": "Ready for Feedback",
         }
         nsb_model = NSB2023List.model_validate(nsb_data)
         mapper = MappedNSBList(nsb=nsb_model)
@@ -998,6 +1015,7 @@ class TestNSB2023FiberImplantMapping(TestCase):
             "Burr1_x0020_Perform_x0020_During": "Initial Surgery",
             "Date_x0020_of_x0020_Surgery": "2022-01-03",
             "IACUC_x0020_Protocol_x0020__x002": "2103",
+            "SurgeryStatus": "Ready for Feedback",
         }
         cls.nsb_model = NSB2023List.model_validate(cls.fiber_data)
         cls.mapper = MappedNSBList(nsb=cls.nsb_model)
@@ -1057,6 +1075,7 @@ class TestNSB2023FiberImplantMapping(TestCase):
             "Fiber_x0020_Implant1_x0020_Lengt": "2.0 mm",
             "IACUC_x0020_Protocol_x0020__x002": "2103",
             "Test1LookupId": 2846,
+            "SurgeryStatus": "Ready for Feedback",
         }
         nsb_model = NSB2023List.model_validate(nsb_data)
         mapper = MappedNSBList(nsb=nsb_model)
@@ -1101,6 +1120,7 @@ class TestNSB2023FiberImplantMapping(TestCase):
             "Fiber_x0020_Implant2_x0020_Lengt": "5.0 mm",
             "Iso_x0020_On": 1.5,
             "HPIsoLevel": 1.8,
+            "SurgeryStatus": "Ready for Feedback",
         }
         nsb_model = NSB2023List.model_validate(nsb_data)
         mapper = MappedNSBList(nsb=nsb_model)
@@ -1134,6 +1154,7 @@ class TestNSB2023FiberImplantMapping(TestCase):
             "Burr_x0020_1_x0020_Fiber_x0020_T": "Standard (Provided by NSB)",
             "Fiber_x0020_Implant1_x0020_Lengt": "2.0 mm",
             "IACUC_x0020_Protocol_x0020__x002": "2103",
+            "SurgeryStatus": "Ready for Feedback",
         }
         nsb_model = NSB2023List.model_validate(nsb_data)
         mapper = MappedNSBList(nsb=nsb_model)
@@ -1171,6 +1192,7 @@ class TestNSB2023FiberImplantMapping(TestCase):
             "Fiber_x0020_Implant1_x0020_Lengt": "2.0 mm",
             "Iso_x0020_On": 1.5,
             "HPIsoLevel": 1.8,
+            "SurgeryStatus": "Ready for Feedback",
         }
         nsb_model = NSB2023List.model_validate(nsb_data)
         mapper = MappedNSBList(nsb=nsb_model)
@@ -1294,6 +1316,7 @@ class TestNSB2023SpinalInjectionMapping(TestCase):
             "Burr1_x0020_Perform_x0020_During": "Initial Surgery",
             "IACUC_x0020_Protocol_x0020__x002": "2103",
             "Test1LookupId": 2846,
+            "SurgeryStatus": "Ready for Feedback",
         }
         nsb_model = NSB2023List.model_validate(nsb_data)
         mapper = MappedNSBList(nsb=nsb_model)
@@ -1330,6 +1353,7 @@ class TestNSB2023SurgeryIntegration(TestCase):
             "Iso_x0020_On": 1.5,
             "HPIsoLevel": 2.0,
             "HPRecovery": 25,
+            "SurgeryStatus": "Ready for Feedback",
         }
 
         cls.fiber_implant_surgery_data = {
@@ -1355,6 +1379,7 @@ class TestNSB2023SurgeryIntegration(TestCase):
             "Iso_x0020_On": 1.5,
             "HPIsoLevel": 1.8,
             "HPRecovery": 30,
+            "SurgeryStatus": "Ready for Feedback",
         }
 
         cls.fiber_followup_surgery_data = {
@@ -1378,6 +1403,7 @@ class TestNSB2023SurgeryIntegration(TestCase):
             "FirstInjectionWeightBefor": 26.5,
             "FirstInjectionWeightAfter": 29.0,
             "WorkStation1stInjection": "SWS 5",
+            "SurgeryStatus": "Ready for Feedback",
         }
 
         cls.hp_cran_model = NSB2023List.model_validate(
@@ -1553,6 +1579,7 @@ class TestNSB2023SurgeryIntegration(TestCase):
             "FileSystemObjectType": 0,
             "Id": 27,
             "IACUC_x0020_Protocol_x0020__x002": "2103",
+            "SurgeryStatus": "Ready for Feedback",
         }
         nsb_model = NSB2023List.model_validate(nsb_data)
         mapper = MappedNSBList(nsb=nsb_model)
@@ -1572,6 +1599,7 @@ class TestNSB2023SurgeryIntegration(TestCase):
             "Procedure": "HP Only",
             "Protocol": "2119 - Training and qualification of animal users",
             "Test1LookupId": 2846,
+            "SurgeryStatus": "Ready for Feedback",
         }
         nsb_model = NSB2023List.model_validate(nsb_data)
         mapper = MappedNSBList(nsb=nsb_model)
@@ -1592,6 +1620,7 @@ class TestNSB2023SurgeryIntegration(TestCase):
             "Procedure": "HP Only",
             "IACUC_x0020_Protocol_x0020__x002": "2103",
             "Test1LookupId": 2846,
+            "SurgeryStatus": "Ready for Feedback",
         }
         nsb_model = NSB2023List.model_validate(nsb_data)
         mapper = MappedNSBList(nsb=nsb_model)
@@ -1613,6 +1642,7 @@ class TestNSB2023SurgeryIntegration(TestCase):
             "Burr1_x0020_Perform_x0020_During": "Follow up Surgery",
             "IACUC_x0020_Protocol_x0020__x002": "2103",
             "test_x0020_1st_x0020_round_x0020_LookupId": 2847,
+            "SurgeryStatus": "Ready for Feedback",
         }
         nsb_model = NSB2023List.model_validate(nsb_data)
         mapper = MappedNSBList(nsb=nsb_model)
@@ -1641,6 +1671,7 @@ class TestNSB2023SurgeryIntegration(TestCase):
             "AP2ndInj": 2.5,
             "DV2ndInj": 3.5,
             "Burr2_x0020_Perform_x0020_During": "Follow up Surgery",
+            "SurgeryStatus": "Ready for Feedback",
         }
         nsb_model = NSB2023List.model_validate(nsb_data)
         mapper = MappedNSBList(nsb=nsb_model)
@@ -1686,6 +1717,7 @@ class TestNSB2023SurgeryIntegration(TestCase):
             "HPIsoLevel": 2.0,
             "IACUC_x0020_Protocol_x0020__x002": "2103",
             "Test1LookupId": 2846,
+            "SurgeryStatus": "Ready for Feedback",
         }
         nsb_model = NSB2023List.model_validate(nsb_data)
         mapper = MappedNSBList(nsb=nsb_model)
@@ -1695,6 +1727,24 @@ class TestNSB2023SurgeryIntegration(TestCase):
         surgery = surgeries[0]
         self.assertIsNotNone(surgery.anaesthesia)
         self.assertEqual(surgery.anaesthesia.level, Decimal("2.0"))
+
+    def test_get_surgeries_no_surgery_status(self):
+        """Test get_surgeries when surgery status is NO_SURGERY"""
+        nsb_data = deepcopy(self.hp_cran_surgery_data)
+        nsb_data["SurgeryStatus"] = "No Surgery"
+        nsb_model = NSB2023List.model_validate(nsb_data)
+        mapper = MappedNSBList(nsb=nsb_model)
+        surgeries = mapper.get_surgeries()
+        self.assertEqual(len(surgeries), 0)
+
+    def test_get_surgeries_none_surgery_status(self):
+        """Test get_surgeries when surgery status is None"""
+        nsb_data = deepcopy(self.fiber_implant_surgery_data)
+        nsb_data["SurgeryStatus"] = None
+        nsb_model = NSB2023List.model_validate(nsb_data)
+        mapper = MappedNSBList(nsb=nsb_model)
+        surgeries = mapper.get_surgeries()
+        self.assertEqual(len(surgeries), 0)
 
 
 class TestNSB2023CoordinateMapping(TestCase):
@@ -1937,6 +1987,7 @@ class TestNSB2023CoordinateMapping(TestCase):
             "Burr2_x0020_Perform_x0020_During": "Initial Surgery",
             "IACUC_x0020_Protocol_x0020__x002": "2103",
             "Test1LookupId": 2846,
+            "SurgeryStatus": "Ready for Feedback",
         }
         nsb_model = NSB2023List.model_validate(nsb_data)
         mapper = MappedNSBList(nsb=nsb_model)

--- a/aind-metadata-service-server/tests/test_mappers/test_procedures.py
+++ b/aind-metadata-service-server/tests/test_mappers/test_procedures.py
@@ -194,6 +194,7 @@ class TestProceduresMapper(unittest.TestCase):
             "FirstInjectionWeightAfter": "19.2",
             "FirstInjectionIsoDuration": "1 hour",
             "Breg2Lamb": "4",
+            "SurgeryStatus": "Ready for Feedback",
         }
         cls.nsb2019 = [NSB2019List.model_validate(nsb2019_data)]
 
@@ -218,6 +219,7 @@ class TestProceduresMapper(unittest.TestCase):
             "HeadpostType": "Mesoscope",
             "CraniotomyType": "5mm",
             "AuthorId": 187,
+            "SurgeryStatus": "Ready for Feedback",
         }
         cls.nsb_2023 = [NSB2023List.model_validate(nsb2023_data)]
 

--- a/aind-metadata-service-server/tests/test_routes/test_procedures.py
+++ b/aind-metadata-service-server/tests/test_routes/test_procedures.py
@@ -175,6 +175,7 @@ class TestRoute:
                 Burr_x0020_1_x0020_Injectable_x0="230929-12",
                 Burr_x0020_1_x0020_Injectable_x03="1e12",
                 Inj1VirusStrain_rt='Premixed "dL+Cre"',
+                SurgeryStatus="Ready for Feedback",
             )
         ]
         mock_nsb_present.return_value = []
@@ -314,6 +315,7 @@ class TestRoute:
                 Burr_x0020_1_x0020_Injectable_x0="UNKNOWN-VIRUS-123",
                 Burr_x0020_1_x0020_Injectable_x03="1e12",
                 Inj1VirusStrain_rt="Unknown strain",
+                SurgeryStatus="Ready for Feedback",
             )
         ]
         mock_nsb_present.return_value = []


### PR DESCRIPTION
closes #696 for V2 procedures endpoint

This PR: 
- Filters out items from both the NSB2019 and NSB2023 lists that explicitly are marked with the `Surgery Status=No Surgery`. 
- Updates all test data with Surgery Status
- A breaking change was introduced in the latest version of the smartsheet client. Pinning the version here for now until we implement the updates in the metadata-service.

Notes:
- Verified the data always has marked `Surgery Status` by downloading both the NSB2023 Present and the NSB2019 lists in pickled files, and then performing value distribution metrics on them (these can be found in the issue conversation). Validated this with Ali and @dbirman 
- Before deploying, verify the list of assets that exist despite no surgeries. 