### PR TITLE
Feat: Adds API endpoint for weight records from Dataverse

### DIFF
--- a/aind-metadata-service-server/pyproject.toml
+++ b/aind-metadata-service-server/pyproject.toml
@@ -24,7 +24,7 @@ dependencies = [
     'aind-smartsheet-service-async-client>=1.1.0',
     'aind-sharepoint-service-async-client>=0.3.0',
     'aind-session-json-service-async-client>=0.1.3',
-    'aind-dataverse-service-async-client>=0.1.0',
+    'aind-dataverse-service-async-client==0.3.0',
     'aind-active-directory-service-async-client>=0.1.3',
     'aind-data-schema==2.8.1',
     'aind-data-schema-models==5.7.3',

--- a/aind-metadata-service-server/pyproject.toml
+++ b/aind-metadata-service-server/pyproject.toml
@@ -24,7 +24,7 @@ dependencies = [
     'aind-smartsheet-service-async-client>=1.1.0',
     'aind-sharepoint-service-async-client>=0.3.0',
     'aind-session-json-service-async-client>=0.1.3',
-    'aind-dataverse-service-async-client==0.3.0',
+    'aind-dataverse-service-async-client>=0.3.0',
     'aind-active-directory-service-async-client>=0.1.3',
     'aind-data-schema==2.8.1',
     'aind-data-schema-models==5.7.3',

--- a/aind-metadata-service-server/src/aind_metadata_service_server/mappers/dataverse.py
+++ b/aind-metadata-service-server/src/aind_metadata_service_server/mappers/dataverse.py
@@ -1,6 +1,12 @@
 """Module to handle dataverse data mapping and filtering"""
 
-from typing import Dict
+import logging
+from datetime import datetime
+from typing import Dict, List, Optional
+
+from aind_metadata_service_server.models import MouseWeightData
+
+logger = logging.getLogger(__name__)
 
 
 def filter_dataverse_metadata(data: Dict) -> Dict:
@@ -31,3 +37,72 @@ def filter_dataverse_metadata(data: Dict) -> Dict:
         return [filter_dataverse_metadata(item) for item in data]
     else:
         return data
+
+
+def map_mouse_weight_records(
+    dataverse_response: List[Dict],
+) -> List[MouseWeightData]:
+    """
+    Map Dataverse mouse weight records to MouseWeightData models.
+
+    Parameters
+    ----------
+    dataverse_response : List[Dict]
+        The raw Dataverse API response as a list of records
+
+    Returns
+    -------
+    List[MouseWeightData]
+        List of mapped MouseWeightData models
+    """
+    if not dataverse_response:
+        return []
+
+    mapped_records = []
+
+    for i, record in enumerate(dataverse_response):
+        mapped_record = MouseWeightData(
+            record_id=record.get("aibs_fact_mouse_weight_recordsid"),
+            mouse_id=record.get(
+                "_aibs_mouse_id_value@OData.Community.Display.V1.FormattedValue"
+            ),
+            weight=record.get("aibs_weight"),
+            weight_datetime=_parse_datetime(
+                record.get("aibs_date_time") or record.get("cr138_datetime")
+            ),
+            is_baseline_weight=record.get("aibs_is_baseline_weight"),
+            operator=record.get(
+                "_aibs_operator_value@OData.Community.Display.V1.FormattedValue"
+            ),
+            workstation=record.get("aibs_workstation"),
+            software_version=record.get("aibs_software_version"),
+            software_source=record.get("aibs_software_source"),
+            status=record.get(
+                "statuscode@OData.Community.Display.V1.FormattedValue"
+            ),
+            notes=record.get("aibs_notes"),
+        )
+        mapped_records.append(mapped_record)
+    return mapped_records
+
+
+def _parse_datetime(dt_str: Optional[str]) -> Optional[datetime]:
+    """
+    Parse ISO datetime string to datetime object.
+
+    Parameters
+    ----------
+    dt_str : Optional[str]
+        ISO format datetime string
+
+    Returns
+    -------
+    Optional[datetime]
+        Parsed datetime object or None
+    """
+    if dt_str is None:
+        return None
+    try:
+        return datetime.fromisoformat(dt_str.replace("Z", "+00:00"))
+    except (ValueError, AttributeError):
+        return None

--- a/aind-metadata-service-server/src/aind_metadata_service_server/mappers/dataverse.py
+++ b/aind-metadata-service-server/src/aind_metadata_service_server/mappers/dataverse.py
@@ -1,12 +1,9 @@
 """Module to handle dataverse data mapping and filtering"""
 
-import logging
 from datetime import datetime
 from typing import Dict, List, Optional
 
 from aind_metadata_service_server.models import MouseWeightData
-
-logger = logging.getLogger(__name__)
 
 
 def filter_dataverse_metadata(data: Dict) -> Dict:

--- a/aind-metadata-service-server/src/aind_metadata_service_server/mappers/dataverse.py
+++ b/aind-metadata-service-server/src/aind_metadata_service_server/mappers/dataverse.py
@@ -69,7 +69,7 @@ def map_mouse_weight_records(
             ),
             weight=record.get("aibs_weight"),
             weight_datetime=_parse_datetime(
-                record.get("aibs_date_time") or record.get("cr138_datetime")
+                record.get("cr138_datetime")
             ),
             is_baseline_weight=record.get("aibs_is_baseline_weight"),
             operator=record.get(

--- a/aind-metadata-service-server/src/aind_metadata_service_server/mappers/dataverse.py
+++ b/aind-metadata-service-server/src/aind_metadata_service_server/mappers/dataverse.py
@@ -64,7 +64,8 @@ def map_mouse_weight_records(
         mapped_record = MouseWeightData(
             record_id=record.get("aibs_fact_mouse_weight_recordsid"),
             mouse_id=record.get(
-                "_aibs_mouse_id_value@OData.Community.Display.V1.FormattedValue"
+                "_aibs_mouse_id_value@OData.Community.Display.V1."
+                "FormattedValue"
             ),
             weight=record.get("aibs_weight"),
             weight_datetime=_parse_datetime(
@@ -72,7 +73,8 @@ def map_mouse_weight_records(
             ),
             is_baseline_weight=record.get("aibs_is_baseline_weight"),
             operator=record.get(
-                "_aibs_operator_value@OData.Community.Display.V1.FormattedValue"
+                "_aibs_operator_value@OData.Community.Display.V1."
+                "FormattedValue"
             ),
             workstation=record.get("aibs_workstation"),
             software_version=record.get("aibs_software_version"),

--- a/aind-metadata-service-server/src/aind_metadata_service_server/models.py
+++ b/aind-metadata-service-server/src/aind_metadata_service_server/models.py
@@ -135,3 +135,37 @@ class EcephysData(SlimsEcephysData):
                     module.manipulator_unit
                 )
         return v
+
+
+class MouseWeightData(BaseModel):
+    """Class for Mouse Weight Data with proper datetime info"""
+
+    record_id: Optional[str] = Field(
+        default=None, description="Unique record ID"
+    )
+    mouse_id: Optional[str] = Field(
+        default=None, description="Subject/Mouse ID"
+    )
+    weight: Optional[float] = Field(
+        default=None, description="Weight in grams"
+    )
+    weight_datetime: Optional[datetime] = Field(
+        default=None, description="When the weight was measured"
+    )
+    is_baseline_weight: Optional[bool] = Field(
+        default=None, description="Whether this is a baseline weight"
+    )
+    operator: Optional[str] = Field(
+        default=None, description="Person who performed the weighing"
+    )
+    workstation: Optional[str] = Field(
+        default=None, description="Workstation where weight was recorded"
+    )
+    software_version: Optional[str] = Field(
+        default=None, description="Software version used"
+    )
+    software_source: Optional[str] = Field(
+        default=None, description="Source system (e.g., WL)"
+    )
+    status: Optional[str] = Field(default=None, description="Record status")
+    notes: Optional[str] = Field(default=None, description="Additional notes")

--- a/aind-metadata-service-server/src/aind_metadata_service_server/routes/dataverse.py
+++ b/aind-metadata-service-server/src/aind_metadata_service_server/routes/dataverse.py
@@ -1,5 +1,7 @@
 """Module to handle dataverse endpoints"""
 
+from datetime import datetime, timedelta
+
 from aind_dataverse_service_async_client.exceptions import ApiException
 from fastapi import APIRouter, Depends, HTTPException, Path, Query
 
@@ -95,4 +97,70 @@ async def get_dataverse_table(
         raise HTTPException(
             status_code=e.status,
             detail=f"Error fetching {entity_set_table_name}: {e.reason}",
+        )
+
+@router.get(
+    "/api/v2/dataverse/mouse_weight_records/{subject_id}",
+    responses={
+        404: {"description": "Not found"},
+    }
+)
+async def get_mouse_weight_records(
+        subject_id: str = Path(
+            ...,
+            description="The subject ID to fetch mouse weight records for",
+            openapi_examples={
+                "default": {
+                    "summary": "A sample subject ID",
+                    "description": "Example subject ID",
+                    "value": "865390",
+                }
+            },
+        ),
+        acquisition_datetime: str | datetime | None = Query(
+            default=None,
+            description="Filter records by acquisition datetime (ISO format string or datetime object)",
+            openapi_examples={
+                "default": {
+                    "summary": "A sample acquisition datetime",
+                    "description": "Example acquisition datetime",
+                    "value": "2026-08-06T00:18:00",
+                }
+            },
+        ),
+    dataverse_api_instance=Depends(get_dataverse_api_instance),
+):
+    """
+    ## Mouse Weight Records
+    Retrieves mouse weight records from Dataverse.
+    """
+    filter_query = f"aibs_mouse_id/aibs_mouse_id eq '{subject_id}'"
+    if acquisition_datetime:
+        # Handle both string and datetime types
+        if isinstance(acquisition_datetime, str):
+            dt_str = acquisition_datetime if acquisition_datetime.endswith('Z') else f"{acquisition_datetime}Z"
+            dt = datetime.fromisoformat(dt_str.replace('Z', '+00:00'))
+        else:
+            # Already a datetime object
+            dt = acquisition_datetime
+        # Get start and end of the day
+        start_of_day = dt.replace(hour=0, minute=0, second=0, microsecond=0)
+        end_of_day = start_of_day + timedelta(days=1)
+        start_str = start_of_day.strftime("%Y-%m-%dT%H:%M:%SZ")
+        end_str = end_of_day.strftime("%Y-%m-%dT%H:%M:%SZ")
+        filter_query += f" and cr138_datetime ge {start_str} and cr138_datetime lt {end_str}"
+    try:
+        dataverse_response = await dataverse_api_instance.get_table(
+            entity_set_table_name="aibs_fact_mouse_weight_recordses",
+            filter=filter_query,
+            _request_timeout=10,
+        )
+        if not dataverse_response:
+            raise HTTPException(status_code=404, detail="Not found")
+        return filter_dataverse_metadata(dataverse_response)
+
+    except ApiException as e:
+        raise HTTPException(
+            status_code=e.status,
+            detail=f"Error fetching mouse weight records: {e.reason}",
         )

--- a/aind-metadata-service-server/src/aind_metadata_service_server/routes/dataverse.py
+++ b/aind-metadata-service-server/src/aind_metadata_service_server/routes/dataverse.py
@@ -147,7 +147,10 @@ async def get_mouse_weight_records(
         end_of_day = start_of_day + timedelta(days=1)
         start_str = start_of_day.strftime("%Y-%m-%dT%H:%M:%SZ")
         end_str = end_of_day.strftime("%Y-%m-%dT%H:%M:%SZ")
-        filter_query += f" and cr138_datetime ge {start_str} and cr138_datetime lt {end_str}"
+        filter_query += (
+            f" and cr138_datetime ge {start_str} "
+            f" and cr138_datetime lt {end_str}"
+        )
     try:
         dataverse_response = await dataverse_api_instance.get_table(
             entity_set_table_name="aibs_fact_mouse_weight_recordses",

--- a/aind-metadata-service-server/src/aind_metadata_service_server/routes/dataverse.py
+++ b/aind-metadata-service-server/src/aind_metadata_service_server/routes/dataverse.py
@@ -1,13 +1,16 @@
 """Module to handle dataverse endpoints"""
 
 from datetime import datetime, timedelta
+from typing import List
 
 from aind_dataverse_service_async_client.exceptions import ApiException
 from fastapi import APIRouter, Depends, HTTPException, Path, Query
 
 from aind_metadata_service_server.mappers.dataverse import (
     filter_dataverse_metadata,
+    map_mouse_weight_records,
 )
+from aind_metadata_service_server.models import MouseWeightData
 from aind_metadata_service_server.sessions import get_dataverse_api_instance
 
 router = APIRouter()
@@ -99,52 +102,48 @@ async def get_dataverse_table(
             detail=f"Error fetching {entity_set_table_name}: {e.reason}",
         )
 
+
 @router.get(
     "/api/v2/dataverse/mouse_weight_records/{subject_id}",
     responses={
         404: {"description": "Not found"},
-    }
+    },
 )
 async def get_mouse_weight_records(
-        subject_id: str = Path(
-            ...,
-            description="The subject ID to fetch mouse weight records for",
-            openapi_examples={
-                "default": {
-                    "summary": "A sample subject ID",
-                    "description": "Example subject ID",
-                    "value": "865390",
-                }
-            },
-        ),
-        acquisition_datetime: str | datetime | None = Query(
-            default=None,
-            description="Filter records by acquisition datetime (ISO format string or datetime object)",
-            openapi_examples={
-                "default": {
-                    "summary": "A sample acquisition datetime",
-                    "description": "Example acquisition datetime",
-                    "value": "2026-08-06T00:18:00",
-                }
-            },
-        ),
+    subject_id: str = Path(
+        ...,
+        description="The subject ID to fetch mouse weight records for",
+        openapi_examples={
+            "default": {
+                "summary": "A sample subject ID",
+                "description": "Example subject ID",
+                "value": "864846",
+            }
+        },
+    ),
+    acquisition_datetime: datetime | None = Query(
+        default=None,
+        description="Filter records by acquisition datetime (ISO format)",
+        openapi_examples={
+            "default": {
+                "summary": "A sample acquisition datetime",
+                "description": "Example acquisition datetime",
+                "value": "2026-08-07T00:18:00",
+            }
+        },
+    ),
     dataverse_api_instance=Depends(get_dataverse_api_instance),
-):
+) -> List[MouseWeightData]:
     """
     ## Mouse Weight Records
     Retrieves mouse weight records from Dataverse.
     """
     filter_query = f"aibs_mouse_id/aibs_mouse_id eq '{subject_id}'"
     if acquisition_datetime:
-        # Handle both string and datetime types
-        if isinstance(acquisition_datetime, str):
-            dt_str = acquisition_datetime if acquisition_datetime.endswith('Z') else f"{acquisition_datetime}Z"
-            dt = datetime.fromisoformat(dt_str.replace('Z', '+00:00'))
-        else:
-            # Already a datetime object
-            dt = acquisition_datetime
-        # Get start and end of the day
-        start_of_day = dt.replace(hour=0, minute=0, second=0, microsecond=0)
+        # Get start and end of the day for date filtering
+        start_of_day = acquisition_datetime.replace(
+            hour=0, minute=0, second=0, microsecond=0
+        )
         end_of_day = start_of_day + timedelta(days=1)
         start_str = start_of_day.strftime("%Y-%m-%dT%H:%M:%SZ")
         end_str = end_of_day.strftime("%Y-%m-%dT%H:%M:%SZ")
@@ -155,9 +154,12 @@ async def get_mouse_weight_records(
             filter=filter_query,
             _request_timeout=10,
         )
-        if not dataverse_response:
+        mouse_weight_records = map_mouse_weight_records(dataverse_response)
+
+        if not mouse_weight_records:
             raise HTTPException(status_code=404, detail="Not found")
-        return filter_dataverse_metadata(dataverse_response)
+
+        return mouse_weight_records
 
     except ApiException as e:
         raise HTTPException(

--- a/aind-metadata-service-server/tests/test_mappers/test_dataverse.py
+++ b/aind-metadata-service-server/tests/test_mappers/test_dataverse.py
@@ -71,18 +71,23 @@ class TestDataverseMapper(unittest.TestCase):
         raw_response = [
             {
                 "cr138_datetime": "2026-08-07T17:30:14Z",
-                "_aibs_operator_value@OData.Community.Display.V1.FormattedValue": "Jaimie Kenney",
-                "statuscode@OData.Community.Display.V1.FormattedValue": "Active",
+                "_aibs_operator_value@OData.Community.Display.V1."
+                "FormattedValue": "Jaimie Kenney",
+                "statuscode@OData.Community.Display.V1."
+                "FormattedValue": "Active",
                 "statuscode": 1,
                 "aibs_weight": 22.1,
-                "aibs_fact_mouse_weight_recordsid": "53882aa8-8592-f111-8077-3833c5ef5e4a",
+                "aibs_fact_mouse_weight_recordsid": (
+                    "53882aa8-8592-f111-8077-3833c5ef5e4a"
+                ),
                 "aibs_date_time": "2026-08-07T17:30:14.710665+00:00",
                 "aibs_software_source": "WL",
                 "aibs_is_baseline_weight": False,
                 "aibs_workstation": "FRG.13-D",
                 "aibs_software_version": "4.1.0.dev7",
-                "_aibs_mouse_id_value@OData.Community.Display.V1.FormattedValue": "864846",
-                "aibs_notes": "Test note",
+                "_aibs_mouse_id_value@OData.Community.Display.V1."
+                "FormattedValue": "864846",
+                "aibs_notes": "Test note"
             }
         ]
 
@@ -119,16 +124,18 @@ class TestDataverseMapper(unittest.TestCase):
         raw_response = [
             {
                 "aibs_fact_mouse_weight_recordsid": "record-1",
-                "_aibs_mouse_id_value@OData.Community.Display.V1.FormattedValue": "123456",
+                "_aibs_mouse_id_value@OData.Community.Display.V1."
+                "FormattedValue": "123456",
                 "aibs_weight": 25.5,
                 "cr138_datetime": "2026-08-07T10:00:00Z",
             },
             {
                 "aibs_fact_mouse_weight_recordsid": "record-2",
-                "_aibs_mouse_id_value@OData.Community.Display.V1.FormattedValue": "789012",
+                "_aibs_mouse_id_value@OData.Community.Display.V1."
+                "FormattedValue": "789012",
                 "aibs_weight": 23.2,
                 "cr138_datetime": "2026-08-07T11:00:00Z",
-            },
+            }
         ]
 
         result = map_mouse_weight_records(raw_response)
@@ -192,15 +199,10 @@ class TestDataverseMapper(unittest.TestCase):
 
     def test_parse_datetime(self):
         """Test parsing datetime strings from Dataverse"""
-        # Test with Z suffix (common Dataverse format)
         result = _parse_datetime("2026-08-07T17:30:14Z")
         self.assertIsNotNone(result)
         self.assertEqual(result.year, 2026)
         self.assertEqual(result.month, 8)
         self.assertEqual(result.day, 7)
-
-        # Test with None
         self.assertIsNone(_parse_datetime(None))
-
-        # Test with invalid string
         self.assertIsNone(_parse_datetime("invalid"))

--- a/aind-metadata-service-server/tests/test_mappers/test_dataverse.py
+++ b/aind-metadata-service-server/tests/test_mappers/test_dataverse.py
@@ -1,10 +1,14 @@
 """Module to test dataverse mapper"""
 
 import unittest
+from datetime import datetime
 
 from aind_metadata_service_server.mappers.dataverse import (
+    _parse_datetime,
     filter_dataverse_metadata,
+    map_mouse_weight_records,
 )
+from aind_metadata_service_server.models import MouseWeightData
 
 
 class TestDataverseMapper(unittest.TestCase):
@@ -61,3 +65,142 @@ class TestDataverseMapper(unittest.TestCase):
             ],
         }
         self.assertEqual(filtered, expected)
+
+    def test_map_mouse_weight_records_success(self):
+        """Test successful mapping of mouse weight records"""
+        raw_response = [
+            {
+                "cr138_datetime": "2026-08-07T17:30:14Z",
+                "_aibs_operator_value@OData.Community.Display.V1.FormattedValue": "Jaimie Kenney",
+                "statuscode@OData.Community.Display.V1.FormattedValue": "Active",
+                "statuscode": 1,
+                "aibs_weight": 22.1,
+                "aibs_fact_mouse_weight_recordsid": "53882aa8-8592-f111-8077-3833c5ef5e4a",
+                "aibs_date_time": "2026-08-07T17:30:14.710665+00:00",
+                "aibs_software_source": "WL",
+                "aibs_is_baseline_weight": False,
+                "aibs_workstation": "FRG.13-D",
+                "aibs_software_version": "4.1.0.dev7",
+                "_aibs_mouse_id_value@OData.Community.Display.V1.FormattedValue": "864846",
+                "aibs_notes": "Test note",
+            }
+        ]
+
+        result = map_mouse_weight_records(raw_response)
+
+        self.assertEqual(len(result), 1)
+        self.assertIsInstance(result[0], MouseWeightData)
+        self.assertEqual(
+            result[0].record_id, "53882aa8-8592-f111-8077-3833c5ef5e4a"
+        )
+        self.assertEqual(result[0].mouse_id, "864846")
+        self.assertEqual(result[0].weight, 22.1)
+        self.assertEqual(result[0].operator, "Jaimie Kenney")
+        self.assertEqual(result[0].workstation, "FRG.13-D")
+        self.assertEqual(result[0].software_version, "4.1.0.dev7")
+        self.assertEqual(result[0].software_source, "WL")
+        self.assertEqual(result[0].status, "Active")
+        self.assertFalse(result[0].is_baseline_weight)
+        self.assertEqual(result[0].notes, "Test note")
+        self.assertIsInstance(result[0].weight_datetime, datetime)
+
+    def test_map_mouse_weight_records_empty(self):
+        """Test mapping with empty response"""
+        result = map_mouse_weight_records([])
+        self.assertEqual(result, [])
+
+    def test_map_mouse_weight_records_none(self):
+        """Test mapping with None response"""
+        result = map_mouse_weight_records(None)
+        self.assertEqual(result, [])
+
+    def test_map_mouse_weight_records_multiple(self):
+        """Test mapping multiple records"""
+        raw_response = [
+            {
+                "aibs_fact_mouse_weight_recordsid": "record-1",
+                "_aibs_mouse_id_value@OData.Community.Display.V1.FormattedValue": "123456",
+                "aibs_weight": 25.5,
+                "cr138_datetime": "2026-08-07T10:00:00Z",
+            },
+            {
+                "aibs_fact_mouse_weight_recordsid": "record-2",
+                "_aibs_mouse_id_value@OData.Community.Display.V1.FormattedValue": "789012",
+                "aibs_weight": 23.2,
+                "cr138_datetime": "2026-08-07T11:00:00Z",
+            },
+        ]
+
+        result = map_mouse_weight_records(raw_response)
+
+        self.assertEqual(len(result), 2)
+        self.assertEqual(result[0].record_id, "record-1")
+        self.assertEqual(result[0].mouse_id, "123456")
+        self.assertEqual(result[0].weight, 25.5)
+        self.assertEqual(result[1].record_id, "record-2")
+        self.assertEqual(result[1].mouse_id, "789012")
+        self.assertEqual(result[1].weight, 23.2)
+
+    def test_map_mouse_weight_records_missing_fields(self):
+        """Test mapping with missing optional fields"""
+        raw_response = [
+            {
+                "aibs_fact_mouse_weight_recordsid": "record-1",
+                "aibs_weight": 25.5,
+                # Missing most optional fields
+            }
+        ]
+
+        result = map_mouse_weight_records(raw_response)
+
+        self.assertEqual(len(result), 1)
+        self.assertEqual(result[0].record_id, "record-1")
+        self.assertEqual(result[0].weight, 25.5)
+        self.assertIsNone(result[0].mouse_id)
+        self.assertIsNone(result[0].operator)
+        self.assertIsNone(result[0].weight_datetime)
+
+    def test_map_mouse_weight_records_prefers_aibs_date_time(self):
+        """Test that aibs_date_time is preferred over cr138_datetime"""
+        raw_response = [
+            {
+                "aibs_fact_mouse_weight_recordsid": "record-1",
+                "aibs_date_time": "2026-08-07T17:30:14.710665+00:00",
+                "cr138_datetime": "2026-08-07T17:30:14Z",
+            }
+        ]
+
+        result = map_mouse_weight_records(raw_response)
+
+        # aibs_date_time has microseconds, cr138_datetime doesn't
+        self.assertEqual(result[0].weight_datetime.microsecond, 710665)
+
+    def test_map_mouse_weight_records_fallback_to_cr138_datetime(self):
+        """Test fallback to cr138_datetime when aibs_date_time is missing"""
+        raw_response = [
+            {
+                "aibs_fact_mouse_weight_recordsid": "record-1",
+                "cr138_datetime": "2026-08-07T17:30:14Z",
+                # aibs_date_time is missing
+            }
+        ]
+
+        result = map_mouse_weight_records(raw_response)
+
+        self.assertIsNotNone(result[0].weight_datetime)
+        self.assertEqual(result[0].weight_datetime.microsecond, 0)
+
+    def test_parse_datetime(self):
+        """Test parsing datetime strings from Dataverse"""
+        # Test with Z suffix (common Dataverse format)
+        result = _parse_datetime("2026-08-07T17:30:14Z")
+        self.assertIsNotNone(result)
+        self.assertEqual(result.year, 2026)
+        self.assertEqual(result.month, 8)
+        self.assertEqual(result.day, 7)
+
+        # Test with None
+        self.assertIsNone(_parse_datetime(None))
+
+        # Test with invalid string
+        self.assertIsNone(_parse_datetime("invalid"))

--- a/aind-metadata-service-server/tests/test_mappers/test_dataverse.py
+++ b/aind-metadata-service-server/tests/test_mappers/test_dataverse.py
@@ -72,22 +72,22 @@ class TestDataverseMapper(unittest.TestCase):
             {
                 "cr138_datetime": "2026-08-07T17:30:14Z",
                 "_aibs_operator_value@OData.Community.Display.V1."
-                "FormattedValue": "Jaimie Kenney",
+                "FormattedValue": "John Doe",
                 "statuscode@OData.Community.Display.V1."
                 "FormattedValue": "Active",
                 "statuscode": 1,
                 "aibs_weight": 22.1,
                 "aibs_fact_mouse_weight_recordsid": (
-                    "53882aa8-8592-f111-8077-3833c5ef5e4a"
+                    "test-record-12345678-1234-1234-1234-123456789abc"
                 ),
                 "aibs_date_time": "2026-08-07T17:30:14.710665+00:00",
                 "aibs_software_source": "WL",
                 "aibs_is_baseline_weight": False,
-                "aibs_workstation": "FRG.13-D",
+                "aibs_workstation": "TEST-WORKSTATION-1",
                 "aibs_software_version": "4.1.0.dev7",
                 "_aibs_mouse_id_value@OData.Community.Display.V1."
-                "FormattedValue": "864846",
-                "aibs_notes": "Test note"
+                "FormattedValue": "123456",
+                "aibs_notes": "Test note",
             }
         ]
 
@@ -96,12 +96,13 @@ class TestDataverseMapper(unittest.TestCase):
         self.assertEqual(len(result), 1)
         self.assertIsInstance(result[0], MouseWeightData)
         self.assertEqual(
-            result[0].record_id, "53882aa8-8592-f111-8077-3833c5ef5e4a"
+            result[0].record_id,
+            "test-record-12345678-1234-1234-1234-123456789abc",
         )
-        self.assertEqual(result[0].mouse_id, "864846")
+        self.assertEqual(result[0].mouse_id, "123456")
         self.assertEqual(result[0].weight, 22.1)
-        self.assertEqual(result[0].operator, "Jaimie Kenney")
-        self.assertEqual(result[0].workstation, "FRG.13-D")
+        self.assertEqual(result[0].operator, "John Doe")
+        self.assertEqual(result[0].workstation, "TEST-WORKSTATION-1")
         self.assertEqual(result[0].software_version, "4.1.0.dev7")
         self.assertEqual(result[0].software_source, "WL")
         self.assertEqual(result[0].status, "Active")
@@ -109,50 +110,45 @@ class TestDataverseMapper(unittest.TestCase):
         self.assertEqual(result[0].notes, "Test note")
         self.assertIsInstance(result[0].weight_datetime, datetime)
 
-    def test_map_mouse_weight_records_empty(self):
-        """Test mapping with empty response"""
-        result = map_mouse_weight_records([])
-        self.assertEqual(result, [])
-
-    def test_map_mouse_weight_records_none(self):
-        """Test mapping with None response"""
-        result = map_mouse_weight_records(None)
-        self.assertEqual(result, [])
+    def test_map_mouse_weight_records_empty_or_none(self):
+        """Test mapping with empty or None response"""
+        self.assertEqual(map_mouse_weight_records([]), [])
+        self.assertEqual(map_mouse_weight_records(None), [])
 
     def test_map_mouse_weight_records_multiple(self):
         """Test mapping multiple records"""
         raw_response = [
             {
-                "aibs_fact_mouse_weight_recordsid": "record-1",
+                "aibs_fact_mouse_weight_recordsid": "test-record-1",
                 "_aibs_mouse_id_value@OData.Community.Display.V1."
-                "FormattedValue": "123456",
+                "FormattedValue": "111111",
                 "aibs_weight": 25.5,
                 "cr138_datetime": "2026-08-07T10:00:00Z",
             },
             {
-                "aibs_fact_mouse_weight_recordsid": "record-2",
+                "aibs_fact_mouse_weight_recordsid": "test-record-2",
                 "_aibs_mouse_id_value@OData.Community.Display.V1."
-                "FormattedValue": "789012",
+                "FormattedValue": "222222",
                 "aibs_weight": 23.2,
                 "cr138_datetime": "2026-08-07T11:00:00Z",
-            }
+            },
         ]
 
         result = map_mouse_weight_records(raw_response)
 
         self.assertEqual(len(result), 2)
-        self.assertEqual(result[0].record_id, "record-1")
-        self.assertEqual(result[0].mouse_id, "123456")
+        self.assertEqual(result[0].record_id, "test-record-1")
+        self.assertEqual(result[0].mouse_id, "111111")
         self.assertEqual(result[0].weight, 25.5)
-        self.assertEqual(result[1].record_id, "record-2")
-        self.assertEqual(result[1].mouse_id, "789012")
+        self.assertEqual(result[1].record_id, "test-record-2")
+        self.assertEqual(result[1].mouse_id, "222222")
         self.assertEqual(result[1].weight, 23.2)
 
     def test_map_mouse_weight_records_missing_fields(self):
         """Test mapping with missing optional fields"""
         raw_response = [
             {
-                "aibs_fact_mouse_weight_recordsid": "record-1",
+                "aibs_fact_mouse_weight_recordsid": "test-record-minimal",
                 "aibs_weight": 25.5,
                 # Missing most optional fields
             }
@@ -161,39 +157,34 @@ class TestDataverseMapper(unittest.TestCase):
         result = map_mouse_weight_records(raw_response)
 
         self.assertEqual(len(result), 1)
-        self.assertEqual(result[0].record_id, "record-1")
+        self.assertEqual(result[0].record_id, "test-record-minimal")
         self.assertEqual(result[0].weight, 25.5)
         self.assertIsNone(result[0].mouse_id)
         self.assertIsNone(result[0].operator)
         self.assertIsNone(result[0].weight_datetime)
 
-    def test_map_mouse_weight_records_prefers_aibs_date_time(self):
-        """Test that aibs_date_time is preferred over cr138_datetime"""
-        raw_response = [
+    def test_map_mouse_weight_records_datetime_handling(self):
+        """Test datetime field preference and fallback behavior"""
+        # Test that aibs_date_time is preferred when both fields exist
+        raw_with_both = [
             {
-                "aibs_fact_mouse_weight_recordsid": "record-1",
+                "aibs_fact_mouse_weight_recordsid": "test-record-datetime-1",
                 "aibs_date_time": "2026-08-07T17:30:14.710665+00:00",
                 "cr138_datetime": "2026-08-07T17:30:14Z",
             }
         ]
-
-        result = map_mouse_weight_records(raw_response)
-
+        result = map_mouse_weight_records(raw_with_both)
         # aibs_date_time has microseconds, cr138_datetime doesn't
         self.assertEqual(result[0].weight_datetime.microsecond, 710665)
 
-    def test_map_mouse_weight_records_fallback_to_cr138_datetime(self):
-        """Test fallback to cr138_datetime when aibs_date_time is missing"""
-        raw_response = [
+        # Test fallback to cr138_datetime when aibs_date_time is missing
+        raw_fallback = [
             {
-                "aibs_fact_mouse_weight_recordsid": "record-1",
+                "aibs_fact_mouse_weight_recordsid": "test-record-datetime-2",
                 "cr138_datetime": "2026-08-07T17:30:14Z",
-                # aibs_date_time is missing
             }
         ]
-
-        result = map_mouse_weight_records(raw_response)
-
+        result = map_mouse_weight_records(raw_fallback)
         self.assertIsNotNone(result[0].weight_datetime)
         self.assertEqual(result[0].weight_datetime.microsecond, 0)
 

--- a/aind-metadata-service-server/tests/test_mappers/test_dataverse.py
+++ b/aind-metadata-service-server/tests/test_mappers/test_dataverse.py
@@ -80,7 +80,6 @@ class TestDataverseMapper(unittest.TestCase):
                 "aibs_fact_mouse_weight_recordsid": (
                     "test-record-12345678-1234-1234-1234-123456789abc"
                 ),
-                "aibs_date_time": "2026-08-07T17:30:14.710665+00:00",
                 "aibs_software_source": "WL",
                 "aibs_is_baseline_weight": False,
                 "aibs_workstation": "TEST-WORKSTATION-1",
@@ -150,7 +149,6 @@ class TestDataverseMapper(unittest.TestCase):
             {
                 "aibs_fact_mouse_weight_recordsid": "test-record-minimal",
                 "aibs_weight": 25.5,
-                # Missing most optional fields
             }
         ]
 
@@ -160,33 +158,23 @@ class TestDataverseMapper(unittest.TestCase):
         self.assertEqual(result[0].record_id, "test-record-minimal")
         self.assertEqual(result[0].weight, 25.5)
         self.assertIsNone(result[0].mouse_id)
-        self.assertIsNone(result[0].operator)
-        self.assertIsNone(result[0].weight_datetime)
 
     def test_map_mouse_weight_records_datetime_handling(self):
-        """Test datetime field preference and fallback behavior"""
-        # Test that aibs_date_time is preferred when both fields exist
-        raw_with_both = [
+        """Test datetime field parsing from cr138_datetime"""
+        raw_response = [
             {
-                "aibs_fact_mouse_weight_recordsid": "test-record-datetime-1",
-                "aibs_date_time": "2026-08-07T17:30:14.710665+00:00",
+                "aibs_fact_mouse_weight_recordsid": "test-record-datetime",
                 "cr138_datetime": "2026-08-07T17:30:14Z",
             }
         ]
-        result = map_mouse_weight_records(raw_with_both)
-        # aibs_date_time has microseconds, cr138_datetime doesn't
-        self.assertEqual(result[0].weight_datetime.microsecond, 710665)
-
-        # Test fallback to cr138_datetime when aibs_date_time is missing
-        raw_fallback = [
-            {
-                "aibs_fact_mouse_weight_recordsid": "test-record-datetime-2",
-                "cr138_datetime": "2026-08-07T17:30:14Z",
-            }
-        ]
-        result = map_mouse_weight_records(raw_fallback)
+        result = map_mouse_weight_records(raw_response)
         self.assertIsNotNone(result[0].weight_datetime)
-        self.assertEqual(result[0].weight_datetime.microsecond, 0)
+        self.assertEqual(result[0].weight_datetime.year, 2026)
+        self.assertEqual(result[0].weight_datetime.month, 8)
+        self.assertEqual(result[0].weight_datetime.day, 7)
+        self.assertEqual(result[0].weight_datetime.hour, 17)
+        self.assertEqual(result[0].weight_datetime.minute, 30)
+        self.assertEqual(result[0].weight_datetime.second, 14)
 
     def test_parse_datetime(self):
         """Test parsing datetime strings from Dataverse"""

--- a/aind-metadata-service-server/tests/test_models.py
+++ b/aind-metadata-service-server/tests/test_models.py
@@ -160,22 +160,6 @@ class TestMouseWeightData(unittest.TestCase):
         self.assertEqual(data.status, "Active")
         self.assertEqual(data.notes, "Test note")
 
-    def test_constructor_with_minimal_fields(self):
-        """Test MouseWeightData constructor with only required fields (all optional)"""
-        data = MouseWeightData()
-
-        self.assertIsNone(data.record_id)
-        self.assertIsNone(data.mouse_id)
-        self.assertIsNone(data.weight)
-        self.assertIsNone(data.weight_datetime)
-        self.assertIsNone(data.is_baseline_weight)
-        self.assertIsNone(data.operator)
-        self.assertIsNone(data.workstation)
-        self.assertIsNone(data.software_version)
-        self.assertIsNone(data.software_source)
-        self.assertIsNone(data.status)
-        self.assertIsNone(data.notes)
-
     def test_constructor_with_partial_fields(self):
         """Test MouseWeightData constructor with some fields"""
         data = MouseWeightData(

--- a/aind-metadata-service-server/tests/test_models.py
+++ b/aind-metadata-service-server/tests/test_models.py
@@ -1,6 +1,7 @@
 """Tests methods in models module"""
 
 import unittest
+from datetime import datetime
 from unittest.mock import MagicMock, patch
 
 from aind_slims_service_async_client.models import (
@@ -12,6 +13,7 @@ from aind_metadata_service_server.models import (
     EcephysData,
     HealthCheck,
     HistologyData,
+    MouseWeightData,
     SpimData,
 )
 
@@ -123,6 +125,80 @@ class TestEcephysData(unittest.TestCase):
         """Tests EcephysData initialization with no stream modules"""
         parsed = EcephysData(**{"stream_modules": None})
         self.assertIsNone(parsed.stream_modules)
+
+
+class TestMouseWeightData(unittest.TestCase):
+    """Tests for MouseWeightData"""
+
+    def test_constructor_with_all_fields(self):
+        """Test MouseWeightData constructor with all fields"""
+        data = MouseWeightData(
+            record_id="test-record-id",
+            mouse_id="123456",
+            weight=25.5,
+            weight_datetime=datetime(2026, 8, 7, 17, 30, 14),
+            is_baseline_weight=False,
+            operator="Test Operator",
+            workstation="TEST-STATION",
+            software_version="1.0.0",
+            software_source="WL",
+            status="Active",
+            notes="Test note",
+        )
+
+        self.assertEqual(data.record_id, "test-record-id")
+        self.assertEqual(data.mouse_id, "123456")
+        self.assertEqual(data.weight, 25.5)
+        self.assertEqual(
+            data.weight_datetime, datetime(2026, 8, 7, 17, 30, 14)
+        )
+        self.assertFalse(data.is_baseline_weight)
+        self.assertEqual(data.operator, "Test Operator")
+        self.assertEqual(data.workstation, "TEST-STATION")
+        self.assertEqual(data.software_version, "1.0.0")
+        self.assertEqual(data.software_source, "WL")
+        self.assertEqual(data.status, "Active")
+        self.assertEqual(data.notes, "Test note")
+
+    def test_constructor_with_minimal_fields(self):
+        """Test MouseWeightData constructor with only required fields (all optional)"""
+        data = MouseWeightData()
+
+        self.assertIsNone(data.record_id)
+        self.assertIsNone(data.mouse_id)
+        self.assertIsNone(data.weight)
+        self.assertIsNone(data.weight_datetime)
+        self.assertIsNone(data.is_baseline_weight)
+        self.assertIsNone(data.operator)
+        self.assertIsNone(data.workstation)
+        self.assertIsNone(data.software_version)
+        self.assertIsNone(data.software_source)
+        self.assertIsNone(data.status)
+        self.assertIsNone(data.notes)
+
+    def test_constructor_with_partial_fields(self):
+        """Test MouseWeightData constructor with some fields"""
+        data = MouseWeightData(
+            mouse_id="789012", weight=23.2, operator="Jane Doe"
+        )
+
+        self.assertEqual(data.mouse_id, "789012")
+        self.assertEqual(data.weight, 23.2)
+        self.assertEqual(data.operator, "Jane Doe")
+        self.assertIsNone(data.record_id)
+        self.assertIsNone(data.weight_datetime)
+
+    def test_model_serialization(self):
+        """Test that model can be serialized to dict"""
+        data = MouseWeightData(
+            record_id="test-id", mouse_id="123456", weight=25.5
+        )
+
+        serialized = data.model_dump()
+
+        self.assertEqual(serialized["record_id"], "test-id")
+        self.assertEqual(serialized["mouse_id"], "123456")
+        self.assertEqual(serialized["weight"], 25.5)
 
 
 if __name__ == "__main__":

--- a/aind-metadata-service-server/tests/test_routes/test_dataverse.py
+++ b/aind-metadata-service-server/tests/test_routes/test_dataverse.py
@@ -54,48 +54,30 @@ class TestDataverseRoutes:
         assert len(mock_api_get.mock_calls) == 1
 
     @patch("aind_dataverse_service_async_client.DefaultApi.get_table")
-    def test_get_dataverse_table_success(
+    def test_get_dataverse_table(
         self,
         mock_api_get: AsyncMock,
         client: TestClient,
     ):
-        """Test successful retrieval of specific table data"""
+        """Test table data retrieval with various scenarios"""
+        # Test successful retrieval
         mock_response = [
             {"cr138_projectid": "123", "cr138_name": "Test Project"}
         ]
         mock_api_get.return_value = mock_response
-
         response = client.get("/api/v2/dataverse/tables/cr138_projects")
-
         assert response.status_code == status.HTTP_200_OK
         result = response.json()
         assert len(result) == 1
         assert result[0]["cr138_projectid"] == "123"
-        assert result[0]["cr138_name"] == "Test Project"
-        assert len(mock_api_get.mock_calls) == 1
 
-    @patch("aind_dataverse_service_async_client.DefaultApi.get_table")
-    def test_get_dataverse_table_not_found(
-        self,
-        mock_api_get: AsyncMock,
-        client: TestClient,
-    ):
-        """Test when table is not found"""
+        # Test not found
         mock_api_get.return_value = None
-
         response = client.get("/api/v2/dataverse/tables/nonexistent_table")
-
         assert response.status_code == status.HTTP_404_NOT_FOUND
         assert response.json() == {"detail": "Not found"}
-        assert len(mock_api_get.mock_calls) == 1
 
-    @patch("aind_dataverse_service_async_client.DefaultApi.get_table")
-    def test_get_dataverse_table_api_exception(
-        self,
-        mock_api_get: AsyncMock,
-        client: TestClient,
-    ):
-        """Test handling of ApiException from dataverse service"""
+        # Test API exception handling
         mock_exception = ApiException(
             http_resp=MagicMock(status=400),
             body='{"error": "Invalid table name"}',
@@ -104,13 +86,10 @@ class TestDataverseRoutes:
         mock_exception.status = 400
         mock_exception.reason = "Bad Request"
         mock_api_get.side_effect = mock_exception
-
         response = client.get("/api/v2/dataverse/tables/invalid_table")
-
         assert response.status_code == status.HTTP_400_BAD_REQUEST
         assert "Error fetching invalid_table" in response.json()["detail"]
         assert "Bad Request" in response.json()["detail"]
-        assert len(mock_api_get.mock_calls) == 1
 
     @patch("aind_dataverse_service_async_client.DefaultApi.get_table")
     def test_get_dataverse_table_with_columns_and_filter(
@@ -146,44 +125,66 @@ class TestDataverseRoutes:
         )
 
     @patch("aind_dataverse_service_async_client.DefaultApi.get_table")
-    def test_get_mouse_weight_records_success(
+    def test_get_mouse_weight_records_success_and_multiple(
         self,
         mock_api_get: AsyncMock,
         client: TestClient,
     ):
         """Test successful retrieval of mouse weight records"""
-        mock_response = [
+        mock_single = [
             {
                 "cr138_datetime": "2026-08-07T17:30:14Z",
                 "_aibs_operator_value@OData.Community.Display.V1"
-                ".FormattedValue": "Jaimie Kenney",
+                ".FormattedValue": "Jane Smith",
                 "statuscode@OData.Community.Display.V1."
                 "FormattedValue": "Active",
                 "aibs_weight": 22.1,
                 "aibs_fact_mouse_weight_recordsid": (
-                    "53882aa8-8592-f111-8077-3833c5ef5e4a"
+                    "test-record-aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
                 ),
                 "aibs_software_source": "WL",
                 "aibs_is_baseline_weight": False,
-                "aibs_workstation": "FRG.13-D",
+                "aibs_workstation": "TEST-WORKSTATION-2",
                 "aibs_software_version": "4.1.0.dev7",
                 "_aibs_mouse_id_value@OData.Community.Display.V1."
-                "FormattedValue": "864846",
+                "FormattedValue": "999999",
             }
         ]
-        mock_api_get.return_value = mock_response
-
-        response = client.get("/api/v2/dataverse/mouse_weight_records/864846")
-
+        mock_api_get.return_value = mock_single
+        response = client.get(
+            "/api/v2/dataverse/mouse_weight_records/999999"
+        )
         assert response.status_code == status.HTTP_200_OK
         result = response.json()
         assert len(result) == 1
-        assert result[0]["mouse_id"] == "864846"
+        assert result[0]["mouse_id"] == "999999"
         assert result[0]["weight"] == 22.1
-        assert result[0]["operator"] == "Jaimie Kenney"
-        assert result[0]["workstation"] == "FRG.13-D"
-        assert result[0]["status"] == "Active"
-        assert result[0]["is_baseline_weight"] is False
+
+        mock_multiple = [
+            {
+                "aibs_fact_mouse_weight_recordsid": "test-record-multi-1",
+                "_aibs_mouse_id_value@OData.Community.Display.V1."
+                "FormattedValue": "777777",
+                "aibs_weight": 22.1,
+                "cr138_datetime": "2026-08-07T10:00:00Z",
+            },
+            {
+                "aibs_fact_mouse_weight_recordsid": "test-record-multi-2",
+                "_aibs_mouse_id_value@OData.Community.Display.V1."
+                "FormattedValue": "777777",
+                "aibs_weight": 22.3,
+                "cr138_datetime": "2026-08-07T14:00:00Z",
+            },
+        ]
+        mock_api_get.return_value = mock_multiple
+        response = client.get("/api/v2/dataverse/mouse_weight_records/777777")
+        assert response.status_code == status.HTTP_200_OK
+        result = response.json()
+        assert len(result) == 2
+        assert result[0]["record_id"] == "test-record-multi-1"
+        assert result[0]["weight"] == 22.1
+        assert result[1]["record_id"] == "test-record-multi-2"
+        assert result[1]["weight"] == 22.3
 
     @patch("aind_dataverse_service_async_client.DefaultApi.get_table")
     def test_get_mouse_weight_records_with_datetime_filter(
@@ -196,15 +197,15 @@ class TestDataverseRoutes:
             {
                 "cr138_datetime": "2026-08-07T17:30:14Z",
                 "_aibs_mouse_id_value@OData.Community.Display.V1."
-                "FormattedValue": "864846",
+                "FormattedValue": "888888",
                 "aibs_weight": 22.1,
-                "aibs_fact_mouse_weight_recordsid": "record-1",
+                "aibs_fact_mouse_weight_recordsid": "test-record-filter",
             }
         ]
         mock_api_get.return_value = mock_response
 
         response = client.get(
-            "/api/v2/dataverse/mouse_weight_records/864846",
+            "/api/v2/dataverse/mouse_weight_records/888888",
             params={"acquisition_datetime": "2026-08-07T00:00:00"},
         )
 
@@ -215,31 +216,24 @@ class TestDataverseRoutes:
         # Verify the filter was constructed correctly
         call_args = mock_api_get.call_args
         filter_arg = call_args.kwargs["filter"]
-        assert "aibs_mouse_id/aibs_mouse_id eq '864846'" in filter_arg
+        assert "aibs_mouse_id/aibs_mouse_id eq '888888'" in filter_arg
         assert "cr138_datetime ge 2026-08-07T00:00:00Z" in filter_arg
         assert "cr138_datetime lt 2026-08-08T00:00:00Z" in filter_arg
 
     @patch("aind_dataverse_service_async_client.DefaultApi.get_table")
-    def test_get_mouse_weight_records_not_found(
+    def test_get_mouse_weight_records_errors(
         self,
         mock_api_get: AsyncMock,
         client: TestClient,
     ):
-        """Test when no mouse weight records are found"""
+        """Test error handling for mouse weight records endpoint"""
+        # Test not found
         mock_api_get.return_value = []
-
-        response = client.get("/api/v2/dataverse/mouse_weight_records/999999")
-
+        response = client.get("/api/v2/dataverse/mouse_weight_records/000000")
         assert response.status_code == status.HTTP_404_NOT_FOUND
         assert response.json() == {"detail": "Not found"}
 
-    @patch("aind_dataverse_service_async_client.DefaultApi.get_table")
-    def test_get_mouse_weight_records_api_exception(
-        self,
-        mock_api_get: AsyncMock,
-        client: TestClient,
-    ):
-        """Test handling of ApiException for mouse weight records"""
+        # Test API exception
         mock_exception = ApiException(
             http_resp=MagicMock(status=500),
             body='{"error": "Internal server error"}',
@@ -248,49 +242,12 @@ class TestDataverseRoutes:
         mock_exception.status = 500
         mock_exception.reason = "Internal Server Error"
         mock_api_get.side_effect = mock_exception
-
-        response = client.get("/api/v2/dataverse/mouse_weight_records/864846")
-
+        response = client.get("/api/v2/dataverse/mouse_weight_records/555555")
         assert response.status_code == status.HTTP_500_INTERNAL_SERVER_ERROR
         assert (
             "Error fetching mouse weight records" in response.json()["detail"]
         )
         assert "Internal Server Error" in response.json()["detail"]
-
-    @patch("aind_dataverse_service_async_client.DefaultApi.get_table")
-    def test_get_mouse_weight_records_multiple(
-        self,
-        mock_api_get: AsyncMock,
-        client: TestClient,
-    ):
-        """Test retrieval of multiple mouse weight records"""
-        mock_response = [
-            {
-                "aibs_fact_mouse_weight_recordsid": "record-1",
-                "_aibs_mouse_id_value@OData.Community.Display.V1."
-                "FormattedValue": "864846",
-                "aibs_weight": 22.1,
-                "cr138_datetime": "2026-08-07T10:00:00Z",
-            },
-            {
-                "aibs_fact_mouse_weight_recordsid": "record-2",
-                "_aibs_mouse_id_value@OData.Community.Display.V1."
-                "FormattedValue": "864846",
-                "aibs_weight": 22.3,
-                "cr138_datetime": "2026-08-07T14:00:00Z",
-            },
-        ]
-        mock_api_get.return_value = mock_response
-
-        response = client.get("/api/v2/dataverse/mouse_weight_records/864846")
-
-        assert response.status_code == status.HTTP_200_OK
-        result = response.json()
-        assert len(result) == 2
-        assert result[0]["record_id"] == "record-1"
-        assert result[0]["weight"] == 22.1
-        assert result[1]["record_id"] == "record-2"
-        assert result[1]["weight"] == 22.3
 
 
 if __name__ == "__main__":

--- a/aind-metadata-service-server/tests/test_routes/test_dataverse.py
+++ b/aind-metadata-service-server/tests/test_routes/test_dataverse.py
@@ -145,6 +145,146 @@ class TestDataverseRoutes:
             _request_timeout=10,
         )
 
+    @patch("aind_dataverse_service_async_client.DefaultApi.get_table")
+    def test_get_mouse_weight_records_success(
+        self,
+        mock_api_get: AsyncMock,
+        client: TestClient,
+    ):
+        """Test successful retrieval of mouse weight records"""
+        mock_response = [
+            {
+                "cr138_datetime": "2026-08-07T17:30:14Z",
+                "_aibs_operator_value@OData.Community.Display.V1.FormattedValue": "Jaimie Kenney",
+                "statuscode@OData.Community.Display.V1.FormattedValue": "Active",
+                "aibs_weight": 22.1,
+                "aibs_fact_mouse_weight_recordsid": "53882aa8-8592-f111-8077-3833c5ef5e4a",
+                "aibs_date_time": "2026-08-07T17:30:14.710665+00:00",
+                "aibs_software_source": "WL",
+                "aibs_is_baseline_weight": False,
+                "aibs_workstation": "FRG.13-D",
+                "aibs_software_version": "4.1.0.dev7",
+                "_aibs_mouse_id_value@OData.Community.Display.V1.FormattedValue": "864846",
+            }
+        ]
+        mock_api_get.return_value = mock_response
+
+        response = client.get("/api/v2/dataverse/mouse_weight_records/864846")
+
+        assert response.status_code == status.HTTP_200_OK
+        result = response.json()
+        assert len(result) == 1
+        assert result[0]["mouse_id"] == "864846"
+        assert result[0]["weight"] == 22.1
+        assert result[0]["operator"] == "Jaimie Kenney"
+        assert result[0]["workstation"] == "FRG.13-D"
+        assert result[0]["status"] == "Active"
+        assert result[0]["is_baseline_weight"] is False
+
+    @patch("aind_dataverse_service_async_client.DefaultApi.get_table")
+    def test_get_mouse_weight_records_with_datetime_filter(
+        self,
+        mock_api_get: AsyncMock,
+        client: TestClient,
+    ):
+        """Test mouse weight records with datetime filter"""
+        mock_response = [
+            {
+                "cr138_datetime": "2026-08-07T17:30:14Z",
+                "_aibs_mouse_id_value@OData.Community.Display.V1.FormattedValue": "864846",
+                "aibs_weight": 22.1,
+                "aibs_fact_mouse_weight_recordsid": "record-1",
+            }
+        ]
+        mock_api_get.return_value = mock_response
+
+        response = client.get(
+            "/api/v2/dataverse/mouse_weight_records/864846",
+            params={"acquisition_datetime": "2026-08-07T00:00:00"},
+        )
+
+        assert response.status_code == status.HTTP_200_OK
+        result = response.json()
+        assert len(result) == 1
+
+        # Verify the filter was constructed correctly
+        call_args = mock_api_get.call_args
+        filter_arg = call_args.kwargs["filter"]
+        assert "aibs_mouse_id/aibs_mouse_id eq '864846'" in filter_arg
+        assert "cr138_datetime ge 2026-08-07T00:00:00Z" in filter_arg
+        assert "cr138_datetime lt 2026-08-08T00:00:00Z" in filter_arg
+
+    @patch("aind_dataverse_service_async_client.DefaultApi.get_table")
+    def test_get_mouse_weight_records_not_found(
+        self,
+        mock_api_get: AsyncMock,
+        client: TestClient,
+    ):
+        """Test when no mouse weight records are found"""
+        mock_api_get.return_value = []
+
+        response = client.get("/api/v2/dataverse/mouse_weight_records/999999")
+
+        assert response.status_code == status.HTTP_404_NOT_FOUND
+        assert response.json() == {"detail": "Not found"}
+
+    @patch("aind_dataverse_service_async_client.DefaultApi.get_table")
+    def test_get_mouse_weight_records_api_exception(
+        self,
+        mock_api_get: AsyncMock,
+        client: TestClient,
+    ):
+        """Test handling of ApiException for mouse weight records"""
+        mock_exception = ApiException(
+            http_resp=MagicMock(status=500),
+            body='{"error": "Internal server error"}',
+            data=None,
+        )
+        mock_exception.status = 500
+        mock_exception.reason = "Internal Server Error"
+        mock_api_get.side_effect = mock_exception
+
+        response = client.get("/api/v2/dataverse/mouse_weight_records/864846")
+
+        assert response.status_code == status.HTTP_500_INTERNAL_SERVER_ERROR
+        assert (
+            "Error fetching mouse weight records" in response.json()["detail"]
+        )
+        assert "Internal Server Error" in response.json()["detail"]
+
+    @patch("aind_dataverse_service_async_client.DefaultApi.get_table")
+    def test_get_mouse_weight_records_multiple(
+        self,
+        mock_api_get: AsyncMock,
+        client: TestClient,
+    ):
+        """Test retrieval of multiple mouse weight records"""
+        mock_response = [
+            {
+                "aibs_fact_mouse_weight_recordsid": "record-1",
+                "_aibs_mouse_id_value@OData.Community.Display.V1.FormattedValue": "864846",
+                "aibs_weight": 22.1,
+                "cr138_datetime": "2026-08-07T10:00:00Z",
+            },
+            {
+                "aibs_fact_mouse_weight_recordsid": "record-2",
+                "_aibs_mouse_id_value@OData.Community.Display.V1.FormattedValue": "864846",
+                "aibs_weight": 22.3,
+                "cr138_datetime": "2026-08-07T14:00:00Z",
+            },
+        ]
+        mock_api_get.return_value = mock_response
+
+        response = client.get("/api/v2/dataverse/mouse_weight_records/864846")
+
+        assert response.status_code == status.HTTP_200_OK
+        result = response.json()
+        assert len(result) == 2
+        assert result[0]["record_id"] == "record-1"
+        assert result[0]["weight"] == 22.1
+        assert result[1]["record_id"] == "record-2"
+        assert result[1]["weight"] == 22.3
+
 
 if __name__ == "__main__":
     pytest.main([__file__])

--- a/aind-metadata-service-server/tests/test_routes/test_dataverse.py
+++ b/aind-metadata-service-server/tests/test_routes/test_dataverse.py
@@ -155,16 +155,20 @@ class TestDataverseRoutes:
         mock_response = [
             {
                 "cr138_datetime": "2026-08-07T17:30:14Z",
-                "_aibs_operator_value@OData.Community.Display.V1.FormattedValue": "Jaimie Kenney",
-                "statuscode@OData.Community.Display.V1.FormattedValue": "Active",
+                "_aibs_operator_value@OData.Community.Display.V1"
+                ".FormattedValue": "Jaimie Kenney",
+                "statuscode@OData.Community.Display.V1."
+                "FormattedValue": "Active",
                 "aibs_weight": 22.1,
-                "aibs_fact_mouse_weight_recordsid": "53882aa8-8592-f111-8077-3833c5ef5e4a",
-                "aibs_date_time": "2026-08-07T17:30:14.710665+00:00",
+                "aibs_fact_mouse_weight_recordsid": (
+                    "53882aa8-8592-f111-8077-3833c5ef5e4a"
+                ),
                 "aibs_software_source": "WL",
                 "aibs_is_baseline_weight": False,
                 "aibs_workstation": "FRG.13-D",
                 "aibs_software_version": "4.1.0.dev7",
-                "_aibs_mouse_id_value@OData.Community.Display.V1.FormattedValue": "864846",
+                "_aibs_mouse_id_value@OData.Community.Display.V1."
+                "FormattedValue": "864846",
             }
         ]
         mock_api_get.return_value = mock_response
@@ -191,7 +195,8 @@ class TestDataverseRoutes:
         mock_response = [
             {
                 "cr138_datetime": "2026-08-07T17:30:14Z",
-                "_aibs_mouse_id_value@OData.Community.Display.V1.FormattedValue": "864846",
+                "_aibs_mouse_id_value@OData.Community.Display.V1."
+                "FormattedValue": "864846",
                 "aibs_weight": 22.1,
                 "aibs_fact_mouse_weight_recordsid": "record-1",
             }
@@ -262,13 +267,15 @@ class TestDataverseRoutes:
         mock_response = [
             {
                 "aibs_fact_mouse_weight_recordsid": "record-1",
-                "_aibs_mouse_id_value@OData.Community.Display.V1.FormattedValue": "864846",
+                "_aibs_mouse_id_value@OData.Community.Display.V1."
+                "FormattedValue": "864846",
                 "aibs_weight": 22.1,
                 "cr138_datetime": "2026-08-07T10:00:00Z",
             },
             {
                 "aibs_fact_mouse_weight_recordsid": "record-2",
-                "_aibs_mouse_id_value@OData.Community.Display.V1.FormattedValue": "864846",
+                "_aibs_mouse_id_value@OData.Community.Display.V1."
+                "FormattedValue": "864846",
                 "aibs_weight": 22.3,
                 "cr138_datetime": "2026-08-07T14:00:00Z",
             },

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -41,7 +41,7 @@ services:
   session_json:
     image: "ghcr.io/allenneuraldynamics/aind-session-json-service-server:0.1.3"
   dataverse:
-    image: "ghcr.io/allenneuraldynamics/aind-dataverse-service-server:0.1.0"
+    image: "ghcr.io/allenneuraldynamics/aind-dataverse-service-server:0.3.0"
     env_file: "env/dataverse.env"
   active_directory:
     image: "ghcr.io/allenneuraldynamics/aind-active-directory-service-server:0.1.3"

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -41,7 +41,7 @@ services:
   session_json:
     image: "ghcr.io/allenneuraldynamics/aind-session-json-service-server:0.1.3"
   dataverse:
-    image: "ghcr.io/allenneuraldynamics/aind-dataverse-service-server:0.3.0"
+    image: "ghcr.io/allenneuraldynamics/aind-dataverse-service-server:0.3.1"
     env_file: "env/dataverse.env"
   active_directory:
     image: "ghcr.io/allenneuraldynamics/aind-active-directory-service-server:0.1.3"


### PR DESCRIPTION
closes #728 

This PR: 
- adds an endpoint to retrieve weight records for a given mouse ID from Dataverse. 
- Optional parameter for acquisition date. It fetches anything within the same date 

Sample response: 
```
[
  {
    "record_id": "f9b8106c-4a6b-f111-ab0b-000d3a11a09d",
    "mouse_id": "864846",
    "weight": 27.6,
    "weight_datetime": "2026-06-18T19:17:59.582240Z",
    "is_baseline_weight": false,
    "operator": "Katrina Nguyen",
    "workstation": "FRG.12-C",
    "software_version": "4.1.0.dev7",
    "software_source": "WL",
    "status": "Active",
    "notes": "www day 3"
  }
]
```

NOTE: adding @patricklatimer as reviewer while Jon's out